### PR TITLE
Add Calculix, update to Py3.12.4, Qt6.7.2

### DIFF
--- a/compile_all.py
+++ b/compile_all.py
@@ -178,7 +178,8 @@ class Compiler:
             f"-D ZLIB_INCLUDE_DIR={self.install_dir}/include",
             f"-D ZLIB_LIBRARY_RELEASE={self.install_dir}/lib/zlib" + to_static(),
             f"-D ZLIB_LIBRARY_DEBUG={self.install_dir}/lib/zlibd" + to_static(),
-            "-D CMAKE_DISABLE_FIND_PACKAGE_SoQt=True",  # Absolutely never find SoQt (it's deprecated and we don't want it!)
+            "-D CMAKE_DISABLE_FIND_PACKAGE_SoQt=True",
+            # Absolutely never find SoQt (it's deprecated and we don't want it!)
         ]
         if self.boost_include_path:
             base.append(f"-D Boost_INCLUDE_DIR={self.boost_include_path}")
@@ -1018,3 +1019,11 @@ class Compiler:
                 return
         extra_args = ["-D BUILD_CXX_LIB=ON -D BUILD_PY_LIB=ON -D BUILD_DOC=OFF"]
         self._build_standard_cmake(extra_args)
+
+    def build_calculix(self, _: None):
+        """Cannot currently build Calculix (it's in Fortran, and we only support MSVC toolchain right now). Extract
+        the relevant files from the downloaded zipfile and copy them"""
+        path_to_ccx_bin = os.path.join(os.getcwd(), "CL35-win64", "bin", "ccx", "218")
+        if not os.path.exists(path_to_ccx_bin):
+            raise RuntimeError("Could not locate Calculix")
+        shutil.copytree(path_to_ccx_bin, os.path.join(self.install_dir, "bin"), dirs_exist_ok=True)

--- a/config.json
+++ b/config.json
@@ -5,11 +5,11 @@
         {
             "name":"python",
             "git-repo":"https://github.com/python/cpython.git",
-            "git-ref":"v3.12.3"
+            "git-ref":"v3.12.4"
         },
         {
             "name":"pip",
-            "note":"Use the ensure_pip Python module to install pip after compiling Python"
+            "note":"Uses the ensure_pip Python module to install pip after compiling Python"
         },
         {
             "name":"setuptools",
@@ -62,7 +62,7 @@
         },
         {
             "name":"qt",
-            "install-directory":"C:\\Qt\\6.7.1\\msvc2019_64"
+            "install-directory":"C:\\Qt\\6.7.2\\msvc2019_64"
         },
         {
             "name":"bzip2",
@@ -113,7 +113,7 @@
         {
             "name":"pyside",
             "git-repo": "http://code.qt.io/pyside/pyside-setup",
-            "git-ref": "v6.7.1"
+            "git-ref": "v6.7.2"
         },
         {
             "name":"vtk",
@@ -207,6 +207,11 @@
             "name": "opencamlib",
             "git-repo": "https://github.com/aewallin/opencamlib",
             "git-ref": "2023.01.11"
+        },
+        {
+            "name":"calculix",
+            "url":"https://drive.usercontent.google.com/download?id=1Z8Mnx9-tyPdPlRi9kdPkFqZhTVA1uemY&export=download&authuser=0&confirm=t&uuid=1808e0cb-38d9-43ea-beea-619109a11527&at=APZUnTWlTXR23jpMPcF6-LBcbOaN:1720405069050",
+            "note":"Difficult to compile with an MSVC toolchain because it is written in Fortran. Direct download link here is from http://calculixforwin.blogspot.com/2015/05/calculix-launcher.html"
         }
     ]
 }


### PR DESCRIPTION
Calculix cannot be compiled with the straight MSVC toolchain (it is written in Fortran), so a pre-built binary is downloaded from a recommended online source. This is not a great solution (that source ends up redirecting to a Google Drive download), but in the short-term it is the only feasible solution.

A long-term alternative is to self-host a Windows-compiled version of Calculix that is built using the mingw/gfortran toolchain.