### PR TITLE
Update zlib

### DIFF
--- a/config.json
+++ b/config.json
@@ -40,7 +40,7 @@
         {
             "name":"zlib",
             "git-repo":"https://github.com/madler/zlib",
-            "git-ref":"v1.3"
+            "git-ref":"v1.3.1"
         },
         {
             "name":"qt",


### PR DESCRIPTION
fix:
Reject overflows of zip header fields in minizip
Fix bug in inflateSync() for data held in bit buffer Add LIT_MEM define to use more memory for a small deflate speedup Fix decision on the emission of Zip64 end records in minizip Add bounds checking to ERR_MSG() macro, used by zError() Neutralize zip file traversal attacks in miniunz
Fix a bug in ZLIB_DEBUG compiles in check_match()