### PR TITLE
Add `cxxstd=20`  flag to boost compilation

### DIFF
--- a/compile_all.py
+++ b/compile_all.py
@@ -473,6 +473,7 @@ class Compiler:
                     "address-model=64",
                     f"architecture={arch}",
                     "link=static,shared",
+                    "cxxstd=20",
                     str(self.mode).lower(),
                     f"--prefix={install_dir}",
                     "--layout=versioned",

--- a/config.json
+++ b/config.json
@@ -1,6 +1,6 @@
 {
     "FreeCAD-version":"1.1.0",
-    "LibPack-version":"3.1.1.2",
+    "LibPack-version":"3.1.1.3",
     "content": [
         {
             "name":"python",


### PR DESCRIPTION
 Boost does not use CMake for compilation, so was not included in the previous attempt to set the C++ standard to C++20 everywhere. This fixes that, and update to v3.1.1.3