### PR TITLE
Disable use of AVX compiler option

### DIFF
--- a/compile_all.py
+++ b/compile_all.py
@@ -1103,6 +1103,7 @@ class Compiler:
             "-D USE_SUPERBUILD=OFF",
             "-D USE_GUI=OFF",
             "-D USE_INTERNAL_TCL=OFF",
+            "-D USE_NATIVE_ARCH=OFF",
             f"-D TCL_DIR={self.install_dir}",
             f"-D TK_DIR={self.install_dir}",
             "-D USE_OCC=On",


### PR DESCRIPTION
### Summary
AVX512 instructions generated in netgen library

### Issue
 if the build machine is , say, AVX512 compatible then unless the option USE_NATIVE_ARCH is OFF the cmake for netgen  will generate compiler options /arch:AVX512 on Win32 and -march=native for other x86_64 systems
This will cause an illegal instruction if the build is run on non AVX512 capable machines.

### Changes
Added -D USE_NATIVE_ARCH=OFF to compile_all.py for netgen

### Testing
Built LibPack and then FreeCAD on a AVX512 capable machine then tested on non-AVX512 capable laptop