### PR TITLE
Download Mesa from Qt's CDN

### DIFF
--- a/compile_all.py
+++ b/compile_all.py
@@ -453,9 +453,7 @@ class Compiler:
             print("  opengl32sw.dll already in the LibPack, not re-copying")
             return
         if platform.machine() == "ARM64":
-            print(
-                "  NOTE: opengl32sw.dll is not available for Windows on ARM64 - Skipping"
-            )
+            print("  NOTE: opengl32sw.dll is not available for Windows on ARM64 - Skipping")
             return
         matches = list(pathlib.Path(os.getcwd()).rglob("opengl32sw.dll"))
         if not matches:

--- a/compile_all.py
+++ b/compile_all.py
@@ -445,6 +445,30 @@ class Compiler:
                 print(e.output.decode("utf-8", errors="replace"))
             exit(1)
 
+    def build_opengl32sw(self, _: None):
+        """Copy Mesa software OpenGL DLL into the LibPack on x64. On ARM64 the DLL is
+        unavailable from Qt's CDN. Does not actually build anything, just copies it."""
+        target = os.path.join(self.install_dir, "bin", "opengl32sw.dll")
+        if self.skip_existing and os.path.exists(target):
+            print("  opengl32sw.dll already in the LibPack, not re-copying")
+            return
+        if platform.machine() == "ARM64":
+            print(
+                "  NOTE: opengl32sw.dll is not available for Windows on ARM64 - Skipping"
+            )
+            return
+        matches = list(pathlib.Path(os.getcwd()).rglob("opengl32sw.dll"))
+        if not matches:
+            print(
+                f"ERROR: opengl32sw.dll not found under {os.getcwd()}. "
+                "The download or 7z extraction probably failed; check the URL "
+                "in config.json and retry."
+            )
+            exit(1)
+        os.makedirs(os.path.dirname(target), exist_ok=True)
+        shutil.copyfile(str(matches[0]), target)
+        print(f"  Copied {matches[0]} to {target}")
+
     def build_qt(self, options: dict):
         """Build Qt from source. Always builds qtbase, qtsvg, qtdeclarative, and qttools
         against the LibPack's own zlib and libpng."""

--- a/config.json
+++ b/config.json
@@ -91,6 +91,11 @@
             "fallback-build-dir": "G:\\temp"
         },
         {
+            "name": "opengl32sw",
+            "url-x64": "https://download.qt.io/online/qtsdkrepository/windows_x86/desktop/qt6_6110/qt6_6110_msvc2022_64/qt.qt6.6110.win64_msvc2022_64/6.11.0-0-202603180535opengl32sw-64-mesa_11_2_2-signed_sha256.7z",
+            "note": "Mesa-based software OpenGL fallback shipped by The Qt Company alongside their precompiled Qt binaries. Required at runtime on systems whose GPU or driver only exposes OpenGL 1.x (common on Windows VMs without GPU passthrough). Qt's from-source build does not produce this DLL, so the LibPack pulls the precompiled file directly from Qt's online installer CDN. The exact archive filename embeds a build timestamp and changes when Qt rebuilds the package; if the URL stops resolving, locate the current archive under the same Updates.xml path. No equivalent prebuilt is published for Windows on ARM64; ARM64 builds skip this entry entirely (see build_opengl32sw)."
+        },
+        {
             "name":"bzip2",
             "git-repo":"https://gitlab.com/bzip2/bzip2.git",
             "git-ref":"bzip2-1.0.8"

--- a/create_libpack.py
+++ b/create_libpack.py
@@ -135,7 +135,7 @@ def fetch_remote_data(config: dict, skip_existing: bool = False):
             download(item["name"], item["url"])
         elif "url-ARM64" in item and platform.machine() == "ARM64":
             download(item["name"], item["url-ARM64"])
-        elif "url-x64" in item:
+        elif "url-x64" in item and platform.machine() == "AMD64":
             download(item["name"], item["url-x64"])
         else:
             # Just make the directory, presumably later code will know what to do


### PR DESCRIPTION
Mesa (software OpenGL) used to be included in the LibPack, when we used a pre-compiled version of Qt. Now that we build it ourselves, it's not included in the distribution, but some people do still need it. Rather than attempting to build Mesa from scratch, just download a copy from Qt's CDN. The only trick there is that the CDN link is a little complex to fetch, so I'm leaving a long note-to-self in the JSON so I remember about the timestamp thing.

Note that there is no ARM64 build of Mesa available from Qt, so only the x64 LibPack will include it. If this turns out to be a problem we will have to switch to building it as part of the LibPack.