### PR TITLE
Create debug build

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,20 +1,20 @@
-This repository is to provide libraries needed to compile FreeCAD under Windows. It is targetted at developers who want to test against the newest versions of libraries (potentially even compiling a new version themselves), and isn't designed for day-to-day use. Most developers should use the Pixi build system instead.
+# FreeCAD Windows Library Package (a.k.a. The LibPack)
 
-LibPack release names include the version of FreeCAD they are expected to work with (e.g. LibPack 1.2.0 v3.4.0 is v3.4.0 of the LibPack, designed to work with FreeCAD 1.2dev). The most recent LibPack is typically only designed to work with the current development branch of FreeCAD. To compile release versions of FreeCAD you typically must use older versions of the LibPack. LibPacks release names include the version of FreeCAD they are designed to work with.
+This repository is to provide libraries needed to compile FreeCAD under Windows. It is targeted at developers who want to test against the newest versions of libraries (potentially even compiling a new version themselves) and isn't designed for day-to-day use. Most developers should use the Pixi build system instead.
 
-The current LibPack, v3.4, is tested to work with [Microsoft Visual Studio](https://en.wikipedia.org/wiki/Microsoft_Visual_C%2B%2B) version 17.14.* (MSVC 143). Visual Studio 2026 may also be used as long as the MSVC v143 toolchain is installed by selecting the v143 toolset via the `--vcvars-ver=14.4` argument to the build script. Note the version numbering is odd: "v143" does in fact correspond to version 14.4. Versions of Visual Studio prior to 17.0 are known not to work (for example, Visual Studio 2019 will not work with LibPack v3, and must use LibPack v2.11). The LibPack has been tested on x64 and ARM64 processors. If using a pre-built package, please make sure you download the one for your architecture. It should be possible to use other compilers such as MinGW, however this is not tested. This LibPack only supports FreeCAD compilation in Release or RelWithDebInfo mode. It may be possible to compile the LibPack in Debug mode, but changes will certainly be required (and patches are welcome). In particular, the pip installation of Numpy will have to be adjusted to compile a debug version of Numpy, which will otherwise fail to load from a debug compilation of Python.
+LibPack release names include the version of FreeCAD they are expected to work with (e.g. LibPack 1.2.0 v3.4.0 is v3.4.0 of the LibPack, designed to work with FreeCAD 1.2dev). The most recent LibPack is typically only designed to work with the current development branch of FreeCAD.
 
-To compile FreeCAD you will need FreeCAD's source code from the [FreeCAD repository](https://github.com/FreeCAD/FreeCAD).
-Version 3.4 of the LibPack was created in May 2026 and is intended for the FreeCAD 1.2 development branch. In
-general, to compile with the LibPack, you will run CMake (either via the GUI or on the command line) and set the following
-variables:
+As of May 2026, the LibPack is designed to work with FreeCAD 1.2dev, and is available for both x64 and ARM64 processors, in Release and Debug modes. Note that Debug builds are *only* compatible with debug builds of FreeCAD and are much larger than the Release builds. Make sure you *really* need it: for most developers, using the Release version and compiling FreeCAD in `RelWithDebInfo` mode is good enough. Builds of the LibPack are available for download from the [Releases page](https://github.com/FreeCAD/FreeCAD-libpack/releases).
+
+The current LibPack, v3.4, is tested to work with [Microsoft Visual Studio](https://en.wikipedia.org/wiki/Microsoft_Visual_C%2B%2B) version 17.14.* (MSVC 143). Visual Studio 2026 may also be used as long as the MSVC v143 toolchain is installed by selecting the v143 toolset via the `--vcvars-ver=14.4` argument to the build script. Note the version numbering is odd: "v143" does in fact correspond to version 14.4. The Debug LibPack is built with `--mode=debug`, produces a `Py_DEBUG` CPython, and source-builds every C extension in the pip set against the `cp3XXd` ABI.
+
+To compile FreeCAD, you will need FreeCAD's source code from the [FreeCAD repository](https://github.com/FreeCAD/FreeCAD). In general, to compile with the LibPack, you will run CMake (either via the GUI or on the command line) and set the following variables:
  * `-D FREECAD_LIBPACK_DIR="C:/Path/To/The/LibPack-1.2.0-v3.4.0-Release"`
  * `-D FREECAD_COPY_LIBPACK_BIN_TO_BUILD=ON`
  * `-D FREECAD_COPY_DEPEND_DIRS_TO_BUILD=ON`
  * `-D FREECAD_COPY_PLUGINS_BIN_TO_BUILD=ON`
 
-(The last three are optional if you intend to run the `INSTALL` target once you have built FreeCAD -- they are needed only
-if you plan to run directly from the build directory.)
+(The last three are optional if you intend to run the `INSTALL` target once you have built FreeCAD -- they are needed only if you plan to run directly from the build directory.)
 
 For further details on how to compile FreeCAD using the LibPack, see the [FreeCAD Wiki](https://wiki.freecad.org/Compile_on_Windows).
 
@@ -30,27 +30,22 @@ To build the LibPack locally, you will need the following:
  * The "requests" Python package (e.g. 'pip install requests')
  * The "diff-match-patch" Python package (e.g. 'pip install diff-match-patch')
  * GNU Bison (for Windows see https://github.com/lexxmark/winflexbison/)
+ * (DEBUG BUILD ONLY) Rust toolchain, e.g. https://rustup.rs/
+ * (DEBUG BUILD ONLY) Fortran toolchain, e.g. LLVM's flang (https://releases.llvm.org/download.html)
 
-With those pieces in place, the next step is to configure the contents of the LibPack by editing `config.json`. This file
-lists the source for each LibPack component. Depending on the component, there are three different ways it might be included:
+With those pieces in place, the next step is to configure the contents of the LibPack by editing `config.json`. This file lists the source for each LibPack component. Depending on the component, there are three different ways it might be included:
 1) Source code checked out from a git repository and built using the local compiler toolchain
 2) A pip package installed to the LibPack directory using the LibPack's Python interpreter
    * Note that `pip` itself is installed using the `ensure_pip` Python module
    * On ARM64, PyPI does not publish wheels for every required package. The earlier fallback to unofficial ARM64 wheels has been removed, since PyPI's ARM64 cp314 wheel coverage is now adequate for the rest of the pip set. The remaining gaps are handled as follows:
      * `definitions`, `httptools`, and `sets` have no published ARM64 wheel on PyPI, so pip builds them from the source distribution using the MSVC ARM64 toolchain.
-     * `ifcopenshell` has no PyPI wheel for any architecture. On x64 it is installed from PyPI; on ARM64 a prebuilt zip is downloaded from builds.ifcopenshell.org and extracted into site-packages by the `build_ifcopenshell` step. Both architectures are pinned to the same upstream version.
+     * `ifcopenshell` has no PyPI wheel for the debug ABI and no ARM64 wheel for any architecture. The config.json entry is hybrid: in Release on x64 it is installed via pip from PyPI, in Release on ARM64 a prebuilt zip is downloaded from builds.ifcopenshell.org and extracted into site-packages by the `build_ifcopenshell` step, and in Debug the source is cloned and built locally with a reduced IFC schema set. All three paths target the same upstream version.
      * `shapely` has no ARM64 wheel on PyPI and no source-build fallback is configured. It is therefore omitted entirely from the ARM64 LibPack, and any FreeCAD feature that depends on it will be unavailable on ARM64 until upstream publishes a wheel or a source-distribution build is integrated.
 3) Compressed files downloaded from a remote source and unpacked (e.g. a pre-built binary for Calculix or libclang)
 
-The JSON file just lists out the sources and versions: beyond specifying which method is used for the installation by setting
-either "git-repo" and "git_ref" (or "git-hash"), or "url" (or "url-x64" and "url-ARM64"), the actual details of how things are built when source
-code is provided are set in the `compile_all.py` script. In that file, the class `Compiler` contains methods following the
-naming convention `build_XXX` where `XXX` is the "name" provided in the JSON configuration file. If you need to add a compiled
-or copied package, you must both specify it in the config.json file and provide a matching `build_XXX` method. For pip
-installation, only the config.json file needs to be edited to include the new dependency.
+The JSON file just lists out the sources and versions: beyond specifying which method is used for the installation by setting either "git-repo" with "git-ref" (or "git-hash"), or "url" (or "url-x64" and "url-ARM64"), the actual details of how things are built when source code is provided are set in the `compile_all.py` script. An entry may declare both a "git-repo" and a "url-*" to express a hybrid: the source is cloned in Debug builds and the prebuilt artifact is downloaded in Release builds. In `compile_all.py`, the class `Compiler` contains methods following the naming convention `build_XXX` where `XXX` is the "name" provided in the JSON configuration file. If you need to add a compiled or copied package, you must both specify it in the config.json file and provide a matching `build_XXX` method. For pip installation, only the config.json file needs to be edited to include the new dependency.
 
-To change the way a package is compiled, you edit its entry in `compile_all.py`. See the contents of that file for various
-examples.
+To change the way a package is compiled, you edit its entry in `compile_all.py`. See the contents of that file for various examples.
 
 ## Running the build script ##
 
@@ -58,7 +53,7 @@ examples.
 python.exe create_libpack [arguments]
 ```
 Arguments:
-* `-m`, `--mode` -- 'release' or 'debug' (Default: 'release' -- debug is not currently functional)
+* `-m`, `--mode` -- 'release' or 'debug' (Default: 'release'). Debug builds Py_DEBUG CPython and source-builds the pip set; expect a substantially longer wall-clock time than Release.
 * `-c`, `--config` -- Path to a JSON configuration file for this utility (Default: './config.json')
 * `-w`, `--working` -- Directory to put all the clones and downloads in (Default: './working')
 * `-e`, `--no-skip-existing-clone` -- If a given clone (or download) directory exists, delete it and download it again
@@ -72,5 +67,4 @@ Arguments:
 
 ## License
 
-The code for the LibPack creation scripts is licensed under the LGPLv2.1+ license. See the LICENSE file for details. Each
-individual component in the LibPack is licensed under its own terms: see the individual component directories for details.
+The code for the LibPack creation scripts is licensed under the LGPLv2.1+ license. See the LICENSE file for details. Each individual component in the LibPack is licensed under its own terms: see the individual component directories for details.

--- a/compile_all.py
+++ b/compile_all.py
@@ -29,38 +29,105 @@ _DEBUG_BUILD_EXCLUDED_REQUIREMENTS = frozenset(
         # Direct C/C++/Fortran/Rust extensions with no pure-Python distribution.
         "cmake",
         "cog",
+        # contourpy uses meson-python and looks up pybind11 via pkg-config in its
+        # meson.build. Windows does not ship pkg-config, so the metadata step fails
+        # before we even get to the C++ compile. Reintroducing this package needs a
+        # meson native file or a pkg-config installation. Other meson-python packages
+        # that bypass pkg-config (numpy, scipy) may work without this complication.
         "contourpy",
-        "debugpy",
-        "httptools",
-        "ifcopenshell",
+        # kiwisolver 1.5.0 sdist reports project version 0.0.0 from meson, not 1.5.0.
+        # Pip's strict metadata check rejects the mismatch. Reintroducing this package
+        # needs either a downgrade to 1.4.x in config.json or a per-package
+        # --config-settings override of the version at pip invocation time.
         "kiwisolver",
+        "ifcopenshell",
         "lxml",
-        "numpy",
+        # Pillow 12.x made libjpeg a required dependency with no env-var or build-flag
+        # escape hatch (the previous "reduced support" path was removed). Reintroducing
+        # this package needs libjpeg-turbo as a LibPack C++ package (build_libjpeg in
+        # compile_all.py and an entry in config.json), or a downgrade to pillow 11.x.
         "pillow",
         "pydantic_core",
-        "PyYAML",
         "shapely",
         "watchfiles",
         # Transitively excluded because their hard dependencies are excluded above.
         "fastapi",
         "matplotlib",
-        "nltk",
-        "pycollada",
         "pydantic",
-        "scipy",
     )
 )
 
-# Build-time pure-Python tooling that must be present even when the rest of the requirements
-# list is skipped. setup.py-based packages built later in the LibPack (PySide, opencamlib)
-# import these at build time.
-_DEBUG_BUILD_REQUIRED_TOOLING = ("packaging", "setuptools", "wheel")
+# Build-time tooling that must be present in the LibPack so that pip's --no-build-isolation
+# can resolve PEP 517 build backends locally. setuptools covers most packages; meson-python
+# covers the modern numerical-Python ecosystem (contourpy, numpy, scipy, matplotlib). meson
+# and ninja are the actual build tools meson-python orchestrates; pyproject-metadata is a
+# meson-python dependency.
+_DEBUG_BUILD_REQUIRED_TOOLING = (
+    "packaging",
+    "setuptools",
+    "wheel",
+    "meson-python",
+    "meson",
+    "ninja",
+    "pyproject-metadata",
+    "cppy",
+    "pybind11",
+    "Cython",
+    "pkgconf",
+    "pythran",
+)
 
 # Packages with C extensions that pip must source-build against the debug Python rather
 # than pull from PyPI as a wheel. Windows Py_DEBUG reports both cp3XXd and cp3XX as
 # compatible platform tags, so without --no-binary pip happily picks a release wheel that
 # then fails to load against python_d.exe at runtime. Names match pip's --no-binary syntax.
-_DEBUG_BUILD_FROM_SOURCE = ("regex",)
+_DEBUG_BUILD_FROM_SOURCE = ("regex", "PyYAML", "httptools", "debugpy", "numpy", "scipy")
+
+# Sitecustomize shim installed at <libpack>/bin/Lib/site-packages/sitecustomize.py for
+# Debug LibPacks. Setuptools' build_ext defaults debug=False even when the target Python
+# is Py_DEBUG, so source-built C extensions get the release CRT (/MD, VCRUNTIME140.dll)
+# instead of the debug CRT (/MDd, VCRUNTIME140D.dll, ucrtbased.dll). The mismatch
+# corrupts heap state in any extension that shares allocations across the C/Python
+# boundary. This shim forces self.debug = True for every build_ext invocation when
+# Py_DEBUG is detected via sysconfig. The unconditional warning at the bottom makes
+# silent monkey-patch failure (for example a future setuptools rename) loud rather than
+# silent.
+_SITECUSTOMIZE_DEBUG_SHIM = '''\
+"""Auto-loaded at interpreter startup by site.execsitecustomize().
+
+When this Python is a Py_DEBUG build, force setuptools' build_ext to default
+debug=True so MSVC compiles C extensions with /MDd (debug CRT) and links with
+/DEBUG:FULL. Setuptools does not consult Py_DEBUG; without this shim, source-
+built extensions get the release CRT and silently corrupt heap state in any
+package that shares allocations across the C/Python boundary.
+
+Installed by the FreeCAD LibPack build (compile_all.build_python, Debug mode)."""
+
+import sys
+import sysconfig
+
+if sysconfig.get_config_var("Py_DEBUG"):
+    _patched = False
+    try:
+        from setuptools.command.build_ext import build_ext as _build_ext
+    except ImportError:
+        _build_ext = None
+    if _build_ext is not None:
+        _orig_initialize_options = _build_ext.initialize_options
+
+        def _initialize_options_force_debug(self):
+            _orig_initialize_options(self)
+            self.debug = True
+
+        _build_ext.initialize_options = _initialize_options_force_debug
+        _patched = True
+    if not _patched:
+        sys.stderr.write(
+            "WARNING: FreeCAD LibPack sitecustomize could not patch setuptools build_ext "
+            "to enforce Py_DEBUG compilation. C extensions built in this interpreter will "
+            "use the release CRT and may corrupt heap state.\\n"
+        )
+'''
 
 
 def _requirement_package_name(spec: str) -> str:
@@ -291,6 +358,49 @@ class Compiler:
     def build_nonexistent(self, _=None):
         """Used for automated testing to allow easy Mock injection"""
 
+    def build_openblas(self, _=None):
+        """Build OpenBLAS, providing BLAS and LAPACK for source-built numpy and scipy
+        in Debug mode. Skipped entirely in Release mode because PyPI numpy and scipy
+        wheels bundle their own OpenBLAS in numpy/.libs/, and nothing else in the
+        Release LibPack consumes BLAS.
+
+        Uses the Ninja CMake generator rather than the default Visual Studio generator
+        because (a) the VS generator does not handle Fortran well and OpenBLAS needs
+        Flang for its Fortran sources, and (b) Ninja sidesteps an MSBuild
+        PlatformToolset resolution failure on VS 2026 installs that ship the v143
+        toolset without the matching Microsoft.VCToolsVersion.v143.default.props.
+        Ninja must be on the build host PATH at the time this runs (typically via
+        'pip install ninja' in the system Python, or a manual ninja.exe placement)."""
+        if self.mode != BuildMode.DEBUG:
+            print(
+                "  Skipping OpenBLAS build in Release mode (numpy/scipy use bundled OpenBLAS from wheels)."
+            )
+            return
+        if self.skip_existing:
+            if os.path.exists(os.path.join(self.install_dir, "include", "openblas", "cblas.h")):
+                print("  Not rebuilding OpenBLAS, it is already in the LibPack")
+                return
+        extra_args = [
+            "-G",
+            "Ninja",
+            "-D BUILD_SHARED_LIBS=ON",
+            # DYNAMIC_ARCH=OFF: with DYNAMIC_ARCH=ON, kernel parameters like
+            # GEMM_UNROLL_MN expand to runtime struct-pointer field accesses
+            # (gotoblas -> ...). OpenBLAS uses those values as array sizes in C
+            # files (driver/level3/zherk_kernel.c, others), which produces VLA
+            # declarations that MSVC's C compiler does not support. In Release the
+            # optimizer constant-folds them; in Debug /Od does not, and the build
+            # fails. A single-arch build resolves the macros to compile-time
+            # constants and side-steps the issue. Debug performance is not a target.
+            "-D DYNAMIC_ARCH=OFF",
+            "-D USE_THREAD=ON",
+            "-D NUM_THREADS=64",
+            "-D BUILD_WITHOUT_LAPACK=OFF",
+            "-D NOFORTRAN=OFF",
+            "-D BUILD_TESTING=OFF",
+        ]
+        self._build_standard_cmake(extra_args=extra_args)
+
     def python_exe(self):
         if self.mode == BuildMode.RELEASE:
             return os.path.join(self.install_dir, "bin", "python") + to_exe()
@@ -477,6 +587,14 @@ class Compiler:
                     os.path.join(bin_dir, f"{versioned}_d.dll"),
                     os.path.join(bin_dir, f"{versioned}.dll"),
                 )
+                site_packages_dir = os.path.join(lib_dir, "site-packages")
+                os.makedirs(site_packages_dir, exist_ok=True)
+                with open(
+                    os.path.join(site_packages_dir, "sitecustomize.py"),
+                    "w",
+                    encoding="utf-8",
+                ) as f:
+                    f.write(_SITECUSTOMIZE_DEBUG_SHIM)
         else:
             raise NotImplemented("Non-Windows compilation of Python is not implemented yet")
 
@@ -524,6 +642,27 @@ class Compiler:
                 kept.append(tool)
         return kept
 
+    def _install_debug_library_aliases(self):
+        """Create release-named copies of debug-suffixed import libraries so that
+        source-built Python C extensions can find them under their conventional names.
+        Pillow's setup.py looks for 'zlib' and 'libpng16' literally, ignoring CMake's
+        'd' debug suffix; numpy and scipy search for BLAS by similarly fixed names.
+        This is a flat list of known-needed aliases rather than a heuristic sweep,
+        because some legitimate library names happen to end in 'd' for unrelated
+        reasons. Aliases are only created when both the debug source exists and the
+        release target does not."""
+        if self.mode != BuildMode.DEBUG:
+            return
+        aliases = (
+            ("lib/zd.lib", "lib/zlib.lib"),
+            ("lib/libpng16d.lib", "lib/libpng16.lib"),
+        )
+        for src, dst in aliases:
+            src_path = os.path.join(self.install_dir, src)
+            dst_path = os.path.join(self.install_dir, dst)
+            if os.path.exists(src_path) and not os.path.exists(dst_path):
+                shutil.copy(src_path, dst_path)
+
     def _install_python_requirements(self, requirements):
         if self.mode == BuildMode.DEBUG:
             requirements = self._filter_debug_requirements(requirements)
@@ -534,9 +673,78 @@ class Compiler:
             ):
                 print("  Not re-installing Python requirements, they are already in the LibPack")
                 return
+        if self.mode == BuildMode.DEBUG:
+            # The main install below uses --no-build-isolation, which requires PEP 517
+            # build backends (setuptools, meson-python, etc.) to already be present in the
+            # LibPack environment. Pip's resolver is single-pass: it cannot install a
+            # backend in the same install request that needs the backend to fetch metadata
+            # for some other package. Bootstrap the tooling first via a separate pip call
+            # with normal isolated builds (the tooling itself is pure-Python or binary, so
+            # isolation is harmless there).
+            print("  Installing build-time tooling")
+            self._run_pip_install(
+                list(_DEBUG_BUILD_REQUIRED_TOOLING),
+                no_build_isolation=False,
+                no_binary_packages=(),
+            )
+            self._install_debug_library_aliases()
         print("  Installing the following requirements (and their dependencies) using pip:")
         for req in requirements:
             print("    " + req)
+        # meson-python defaults to "-Dbuildtype=release -Db_ndebug=if-release -Db_vscrt=md"
+        # regardless of the target Python's debug-ness. b_vscrt=md forces /MD (release
+        # CRT) independently of buildtype, so overriding only buildtype leaves extensions
+        # linked against VCRUNTIME140.dll. Pass both -Dbuildtype=debug (so meson selects
+        # debug compile flags and no NDEBUG) and -Db_vscrt=mdd (so the linker uses
+        # ucrtbased.dll and VCRUNTIME140D.dll).
+        # blas=openblas / lapack=openblas point numpy at the LibPack-built OpenBLAS;
+        # meson's dependency() finds it via pkg-config (PKG_CONFIG_PATH) or CMake
+        # (CMAKE_PREFIX_PATH), both set in the subprocess env above.
+        config_settings = (
+            (
+                ("setup-args", "-Dbuildtype=debug"),
+                ("setup-args", "-Db_vscrt=mdd"),
+                ("setup-args", "-Dblas=openblas"),
+                ("setup-args", "-Dlapack=openblas"),
+                # cpp_std=c++17 is required for pythran-generated C++ in scipy. Pythran's
+                # generated headers still use std::result_of_t, which C++20 removed.
+                # MSVC's default standard is newer than C++17 in current toolsets, so we
+                # pin it explicitly. Numpy's own meson.build already pins c++17, so this
+                # change is a no-op for numpy and a fix for scipy.
+                ("setup-args", "-Dcpp_std=c++17"),
+            )
+            if self.mode == BuildMode.DEBUG
+            else ()
+        )
+        # Scipy needs an extra meson option that other meson-python projects (numpy in
+        # particular) reject as unknown. Pull it out for a separate pip pass.
+        scipy_specs: list = []
+        if self.mode == BuildMode.DEBUG:
+            scipy_specs = [r for r in requirements if _requirement_package_name(r) == "scipy"]
+            if scipy_specs:
+                requirements = [r for r in requirements if _requirement_package_name(r) != "scipy"]
+        self._run_pip_install(
+            requirements,
+            no_build_isolation=(self.mode == BuildMode.DEBUG),
+            no_binary_packages=(_DEBUG_BUILD_FROM_SOURCE if self.mode == BuildMode.DEBUG else ()),
+            config_settings=config_settings,
+        )
+        if scipy_specs:
+            print("  Installing scipy with use-pythran=false")
+            self._run_pip_install(
+                scipy_specs,
+                no_build_isolation=True,
+                no_binary_packages=("scipy",),
+                # Pythran 0.18 headers fail to compile under MSVC for scipy's
+                # pythran-translated modules (a ref-qualifier overload mismatch in
+                # ndarray.hpp). Disabling pythran skips those modules; scipy provides
+                # pure-Python fallbacks for each.
+                config_settings=config_settings + (("setup-args", "-Duse-pythran=false"),),
+            )
+
+    def _run_pip_install(
+        self, requirements, no_build_isolation, no_binary_packages, config_settings=()
+    ):
         path_to_python = self.python_exe()
         pip_args = [
             path_to_python,
@@ -547,16 +755,45 @@ class Compiler:
             "--ignore-installed",
             "--no-warn-script-location",
         ]
-        if self.mode == BuildMode.DEBUG:
-            for pkg in _DEBUG_BUILD_FROM_SOURCE:
-                pip_args.extend(["--no-binary", pkg])
+        if no_build_isolation:
+            pip_args.append("--no-build-isolation")
+        for pkg in no_binary_packages:
+            pip_args.extend(["--no-binary", pkg])
+        for key, value in config_settings:
+            pip_args.append(f"--config-settings={key}={value}")
         pip_args.extend(requirements)
         if self.mode == BuildMode.DEBUG:
             # Source-built C extensions need MSVC visible. Source vcvars first and tell
             # setuptools to trust the existing SDK env instead of auto-detecting compilers.
+            # Also expose the LibPack's Scripts directory on PATH so build backends like
+            # meson-python can find the meson and ninja executables that were installed
+            # alongside their Python packages, and prepend the LibPack's include and lib
+            # directories to INCLUDE and LIB so packages built against LibPack-bundled
+            # C/C++ libraries (pillow against libpng, zlib, freetype, for example) find
+            # their headers and import libs.
             env = os.environ.copy()
             env["DISTUTILS_USE_SDK"] = "1"
             env["MSSdk"] = "1"
+            scripts_dir = os.path.join(self.install_dir, "bin", "Scripts")
+            bin_dir = os.path.join(self.install_dir, "bin")
+            env["PATH"] = scripts_dir + os.pathsep + bin_dir + os.pathsep + env.get("PATH", "")
+            include_dir = os.path.join(self.install_dir, "include")
+            python_include_dir = os.path.join(self.install_dir, "bin", "Include")
+            lib_dir = os.path.join(self.install_dir, "lib")
+            python_lib_dir = os.path.join(self.install_dir, "bin", "libs")
+            env["INCLUDE"] = (
+                include_dir + os.pathsep + python_include_dir + os.pathsep + env.get("INCLUDE", "")
+            )
+            env["LIB"] = lib_dir + os.pathsep + python_lib_dir + os.pathsep + env.get("LIB", "")
+            # Tell pkg-config and CMake where to find LibPack-installed packages so meson's
+            # dependency() resolves OpenBLAS (and any future LibPack-bundled lib) by either
+            # method. pkg-config is the preferred lookup for numpy and scipy; CMake is the
+            # fallback meson tries when pkg-config does not find a match.
+            pkgconfig_dir = os.path.join(self.install_dir, "lib", "pkgconfig")
+            env["PKG_CONFIG_PATH"] = pkgconfig_dir + os.pathsep + env.get("PKG_CONFIG_PATH", "")
+            env["CMAKE_PREFIX_PATH"] = (
+                self.install_dir + os.pathsep + env.get("CMAKE_PREFIX_PATH", "")
+            )
             call_args = [*self.init_script, "&", *pip_args]
         else:
             env = None

--- a/compile_all.py
+++ b/compile_all.py
@@ -205,7 +205,7 @@ class Compiler:
             if platform.machine() == "ARM64":
                 base.append("-A ARM64")
             inc_path = self.install_dir.replace("\\", "/")
-            cxx_flags = f"/I{inc_path}/include /EHsc  /DWIN32 /DWIN64 /DNOMINMAX"
+            cxx_flags = f"/I{inc_path}/include /EHsc  /DWIN32 /DWIN64 /DNOMINMAX /DPy_NO_LINK_LIB"
             if self.strict_mode:
                 # NOTE: /permissive- is required with Qt6 but could be disabled for anything that doesn't link against
                 # Qt. The same is true for /Zc:__cplusplus /std:c++20

--- a/compile_all.py
+++ b/compile_all.py
@@ -180,13 +180,23 @@ class Compiler:
             f"-D Python_DIR={self.install_dir}/bin",
             f"-D Python3_ROOT_DIR={self.install_dir}/bin",
             f"-D Python3_DIR={self.install_dir}/bin",
+            f"-D Python_EXECUTABLE={self.python_exe()}",
+            f"-D Python3_EXECUTABLE={self.python_exe()}",
             "-D Python_FIND_REGISTRY=NEVER",
+            "-D Python3_FIND_REGISTRY=NEVER",
             f"-D Qt6_DIR={self.install_dir}/lib/cmake/Qt6",
             f"-D SWIG_EXECUTABLE={self.install_dir}/bin/swig" + to_exe(),
             f"-D ZLIB_DIR={self.install_dir}/lib/cmake/",
             "-D CMAKE_DISABLE_FIND_PACKAGE_SoQt=True",
             # Absolutely never find SoQt (it's deprecated and we don't want it!)
         ]
+        if self.mode == BuildMode.DEBUG:
+            base.append("-D Python_FIND_ABI=ON;ANY;ANY")
+            base.append("-D Python3_FIND_ABI=ON;ANY;ANY")
+            python_lib = self._python_lib_path()
+            if python_lib:
+                base.append(f"-D Python_LIBRARY={python_lib}")
+                base.append(f"-D Python3_LIBRARY={python_lib}")
         if self.boost_include_path:
             base.append(f"-D Boost_INCLUDE_DIR={self.boost_include_path}")
         if self.coin_cmake_path:
@@ -235,6 +245,21 @@ class Compiler:
             return os.path.join(self.install_dir, "bin", "python") + to_exe()
         return os.path.join(self.install_dir, "bin", "python_d") + to_exe()
 
+    def _python_lib_path(self) -> Optional[str]:
+        """Locate the versioned Python import library in the LibPack libs directory,
+        for example python314.lib (release) or python314_d.lib (debug). Returns None
+        if the libs directory or matching file does not yet exist, which is expected
+        before build_python has run."""
+        libs_dir = os.path.join(self.install_dir, "bin", "libs")
+        if not os.path.isdir(libs_dir):
+            return None
+        suffix = "_d" if self.mode == BuildMode.DEBUG else ""
+        pattern = re.compile(rf"^python\d{{2,}}{re.escape(suffix)}\.lib$")
+        for name in os.listdir(libs_dir):
+            if pattern.match(name):
+                return os.path.join(libs_dir, name)
+        return None
+
     def _python_build_env(self):
         """Environment for the host Python that PCbuild\\build.bat -e launches to fetch
         external sources. Some Python installs on Windows ship without a usable CA bundle,
@@ -256,7 +281,7 @@ class Compiler:
 
     def build_python(self, args=None):
         if self.skip_existing:
-            if os.path.exists(os.path.join(self.install_dir, "bin", "DLLs")):
+            if os.path.exists(self.python_exe()):
                 print("  Not rebuilding Python, it is already in the LibPack")
                 return
         if sys.platform.startswith("win32"):
@@ -349,9 +374,10 @@ class Compiler:
                 shutil.copytree(f"Tools\\{sub}", os.path.join(tools_dir, sub), dirs_exist_ok=True)
 
             # Figure out what version of Python we just built:
-            major, minor = self.get_python_version(
-                os.path.join("PCBuild", path, "python.exe")
-            ).split(".")
+            exe_name = "python.exe" if self.mode == BuildMode.RELEASE else "python_d.exe"
+            major, minor = self.get_python_version(os.path.join("PCBuild", path, exe_name)).split(
+                "."
+            )
 
             # Construct the list of files we expect to exist that need to be placed in the toplevel directory, or in
             # libs:
@@ -419,8 +445,17 @@ class Compiler:
             exit(1)
 
     def _install_python_requirements(self, requirements):
+        if self.mode == BuildMode.DEBUG:
+            # PyPI wheels are tagged cp3XX and cannot install against Py_DEBUG (cp3XXd).
+            # For now, install only pure-Python tooling that setup.py-based packages need at build
+            # time later in the LibPack (PySide, opencamlib, and so on). Once I get this working as
+            # far as it can, I'll start actually compiling the debug wheels.
+            requirements = ["packaging", "setuptools", "wheel"]
+        sentinel = "packaging" if self.mode == BuildMode.DEBUG else "PIL"
         if self.skip_existing:
-            if os.path.exists(os.path.join(self.install_dir, "bin", "Lib", "site-packages", "PIL")):
+            if os.path.exists(
+                os.path.join(self.install_dir, "bin", "Lib", "site-packages", sentinel)
+            ):
                 print("  Not re-installing Python requirements, they are already in the LibPack")
                 return
         print("  Installing the following requirements (and their dependencies) using pip:")
@@ -472,7 +507,7 @@ class Compiler:
         against the LibPack's own zlib and libpng."""
         if self.skip_existing:
             if os.path.exists(os.path.join(self.install_dir, "metatypes")):
-                print("Not building Qt from source, it already seems to be in the LibPack")
+                print("  Not rebuilding Qt, it is already in the LibPack")
                 return
 
         build_dir = os.path.join(os.getcwd(), f"build-{str(self.mode).lower()}")
@@ -496,7 +531,10 @@ class Compiler:
 
         # Qt needs access to zlib and libpng, and assumes they are installed at the system level. We want to
         # use the LibPack versions. The easiest thing to do is just copy the DLLs:
-        files = ["z.dll", "libpng16.dll"]
+        if self.mode == BuildMode.DEBUG:
+            files = ["zd.dll", "libpng16d.dll"]
+        else:
+            files = ["z.dll", "libpng16.dll"]
         source = os.path.join(self.install_dir, "bin")
         destination = os.path.join(build_dir, "qtbase", "bin")
         os.makedirs(destination, exist_ok=True)
@@ -518,6 +556,8 @@ class Compiler:
             "-opengl",
             "desktop",
         ]
+        if self.mode == BuildMode.DEBUG:
+            init_command.append("-debug")
         try:
             self._run_streaming(init_command, "configure_log.txt")
         except subprocess.CalledProcessError as e:

--- a/compile_all.py
+++ b/compile_all.py
@@ -39,7 +39,6 @@ _DEBUG_BUILD_EXCLUDED_REQUIREMENTS = frozenset(
         "pillow",
         "pydantic_core",
         "PyYAML",
-        "regex",
         "shapely",
         "watchfiles",
         # Transitively excluded because their hard dependencies are excluded above.
@@ -56,6 +55,12 @@ _DEBUG_BUILD_EXCLUDED_REQUIREMENTS = frozenset(
 # list is skipped. setup.py-based packages built later in the LibPack (PySide, opencamlib)
 # import these at build time.
 _DEBUG_BUILD_REQUIRED_TOOLING = ("packaging", "setuptools", "wheel")
+
+# Packages with C extensions that pip must source-build against the debug Python rather
+# than pull from PyPI as a wheel. Windows Py_DEBUG reports both cp3XXd and cp3XX as
+# compatible platform tags, so without --no-binary pip happily picks a release wheel that
+# then fails to load against python_d.exe at runtime. Names match pip's --no-binary syntax.
+_DEBUG_BUILD_FROM_SOURCE = ("regex",)
 
 
 def _requirement_package_name(spec: str) -> str:
@@ -533,7 +538,7 @@ class Compiler:
         for req in requirements:
             print("    " + req)
         path_to_python = self.python_exe()
-        call_args = [
+        pip_args = [
             path_to_python,
             "-m",
             "pip",
@@ -542,9 +547,22 @@ class Compiler:
             "--ignore-installed",
             "--no-warn-script-location",
         ]
-        call_args.extend(requirements)
+        if self.mode == BuildMode.DEBUG:
+            for pkg in _DEBUG_BUILD_FROM_SOURCE:
+                pip_args.extend(["--no-binary", pkg])
+        pip_args.extend(requirements)
+        if self.mode == BuildMode.DEBUG:
+            # Source-built C extensions need MSVC visible. Source vcvars first and tell
+            # setuptools to trust the existing SDK env instead of auto-detecting compilers.
+            env = os.environ.copy()
+            env["DISTUTILS_USE_SDK"] = "1"
+            env["MSSdk"] = "1"
+            call_args = [*self.init_script, "&", *pip_args]
+        else:
+            env = None
+            call_args = pip_args
         try:
-            self._run_streaming(call_args, "pip_log.txt")
+            self._run_streaming(call_args, "pip_log.txt", env=env)
         except subprocess.CalledProcessError as e:
             print(f"ERROR: Failed to pip install requirements")
             if e.output:

--- a/compile_all.py
+++ b/compile_all.py
@@ -9,6 +9,7 @@ from diff_match_patch import diff_match_patch
 from typing import Dict, List, Optional, Tuple
 
 from enum import Enum
+import glob
 import os
 import pathlib
 import platform
@@ -706,6 +707,29 @@ class Compiler:
                     os.path.join(bin_dir, f"{versioned}_d.dll"),
                     os.path.join(bin_dir, f"{versioned}.dll"),
                 )
+                # FreeCAD's CMake (and CMake's own FindPython) searches for python.exe
+                # and pythonw.exe by their release names. Provide same-content copies
+                # next to the debug-suffixed originals so downstream consumers find a
+                # Python executable inside the LibPack instead of escaping to a system
+                # install with a different ABI.
+                for exe_pair in (("python_d.exe", "python.exe"), ("pythonw_d.exe", "pythonw.exe")):
+                    src = os.path.join(bin_dir, exe_pair[0])
+                    dst = os.path.join(bin_dir, exe_pair[1])
+                    if os.path.exists(src):
+                        shutil.copy(src, dst)
+                # Python's installed import libraries live at <install>/bin/libs/, the
+                # location FindPython expects. However, anything that transitively
+                # includes Python.h triggers `#pragma comment(lib, "pythonXY_d.lib")`,
+                # and that auto-link only finds the file when the linker's search path
+                # already covers <install>/bin/libs/. Downstream consumers (such as
+                # FreeCAD's own CMake) typically only add <install>/lib/ to the linker
+                # search path. Mirror both libs into <install>/lib/ so the auto-link
+                # resolves without requiring downstream configuration changes.
+                top_lib_dir = os.path.join(self.install_dir, "lib")
+                for lib_name in (f"{versioned}_d.lib", f"{versioned}.lib"):
+                    src = os.path.join(libs_dir, lib_name)
+                    if os.path.exists(src):
+                        shutil.copy(src, os.path.join(top_lib_dir, lib_name))
                 site_packages_dir = os.path.join(lib_dir, "site-packages")
                 os.makedirs(site_packages_dir, exist_ok=True)
                 with open(
@@ -1574,6 +1598,38 @@ class Compiler:
 
         os.chdir(cwd)
 
+        if self.mode == BuildMode.DEBUG and sys.platform.startswith("win32"):
+            # OCCT's install layout for Debug places DLLs in <install>/bind/ and
+            # import libraries in <install>/libd/, ignoring INSTALL_DIR_BIN and
+            # INSTALL_DIR_LIB. Downstream consumers (FreeCAD, every workbench
+            # .pyd) look for these libraries in <install>/bin/ and <install>/lib/.
+            # Merge them in-place and remove the now-empty source directories.
+            for src_name, dst_name in (("bind", "bin"), ("libd", "lib")):
+                src = os.path.join(self.install_dir, src_name)
+                dst = os.path.join(self.install_dir, dst_name)
+                if not os.path.isdir(src):
+                    continue
+                for entry in os.listdir(src):
+                    src_path = os.path.join(src, entry)
+                    dst_path = os.path.join(dst, entry)
+                    if os.path.exists(dst_path):
+                        continue
+                    shutil.copy2(src_path, dst_path)
+                shutil.rmtree(src, onerror=remove_readonly)
+            # OCCT's per-config Targets files reference the original bind/ and
+            # libd/ paths. Rewrite them to point at the merged locations so that
+            # find_package(OpenCASCADE) succeeds in downstream builds.
+            occt_targets = glob.glob(
+                os.path.join(self.install_dir, "cmake", "OpenCASCADE*Targets-debug.cmake")
+            )
+            for target_file in occt_targets:
+                with open(target_file, "r", encoding="utf-8") as fh:
+                    text = fh.read()
+                text = text.replace("${_IMPORT_PREFIX}/libd/", "${_IMPORT_PREFIX}/lib/")
+                text = text.replace("${_IMPORT_PREFIX}/bind/", "${_IMPORT_PREFIX}/bin/")
+                with open(target_file, "w", encoding="utf-8") as fh:
+                    fh.write(text)
+
         # TODO - something is getting messed up in the CMake config output (note the quotes around 26812): for now just
         # drop the line entirely
         # set (OpenCASCADE_CXX_FLAGS    "[...] /wd"26812" /MP /W4")
@@ -1796,7 +1852,8 @@ class Compiler:
         # LibPack's site-packages.
         site_packages = os.path.join(self.install_dir, "bin", "Lib", "site-packages")
         if self.skip_existing:
-            if os.path.exists(os.path.join(site_packages, "opencamlib", "ocl.pyd")):
+            sentinel_name = "ocl_d.pyd" if self.mode == BuildMode.DEBUG else "ocl.pyd"
+            if os.path.exists(os.path.join(site_packages, "opencamlib", sentinel_name)):
                 print("  Not rebuilding opencamlib, it is already in the LibPack")
                 return
         extra_args = [

--- a/compile_all.py
+++ b/compile_all.py
@@ -191,8 +191,6 @@ class Compiler:
             # Absolutely never find SoQt (it's deprecated and we don't want it!)
         ]
         if self.mode == BuildMode.DEBUG:
-            base.append("-D Python_FIND_ABI=ON;ANY;ANY")
-            base.append("-D Python3_FIND_ABI=ON;ANY;ANY")
             python_lib = self._python_lib_path()
             if python_lib:
                 base.append(f"-D Python_LIBRARY={python_lib}")
@@ -205,7 +203,9 @@ class Compiler:
             if platform.machine() == "ARM64":
                 base.append("-A ARM64")
             inc_path = self.install_dir.replace("\\", "/")
-            cxx_flags = f"/I{inc_path}/include /EHsc  /DWIN32 /DWIN64 /DNOMINMAX /DPy_NO_LINK_LIB"
+            cxx_flags = (
+                f"/I{inc_path}/include /EHsc /FS /DWIN32 /DWIN64 /DNOMINMAX /DPy_NO_LINK_LIB"
+            )
             if self.strict_mode:
                 # NOTE: /permissive- is required with Qt6 but could be disabled for anything that doesn't link against
                 # Qt. The same is true for /Zc:__cplusplus /std:c++20
@@ -409,6 +409,23 @@ class Compiler:
                 os.unlink(target)
             print(f"Copying {pyconfig} to {target}")
             shutil.copyfile(pyconfig, target)
+            if self.mode == BuildMode.DEBUG:
+                # FindPython on Windows searches for the release-named library and runtime
+                # DLL independently of any debug-variant hint. Without same-named files in
+                # the LibPack the search escapes to a system Python install and downstream
+                # find_dependency(Python COMPONENTS Development) calls (boost_python's
+                # installed config) reject Development.Embed because the debug library and
+                # release runtime resolve to different installs. Same-content release-named
+                # copies keep every component lookup inside the LibPack.
+                versioned = f"python{major}{minor}"
+                shutil.copy(
+                    os.path.join(libs_dir, f"{versioned}_d.lib"),
+                    os.path.join(libs_dir, f"{versioned}.lib"),
+                )
+                shutil.copy(
+                    os.path.join(bin_dir, f"{versioned}_d.dll"),
+                    os.path.join(bin_dir, f"{versioned}.dll"),
+                )
         else:
             raise NotImplemented("Non-Windows compilation of Python is not implemented yet")
 

--- a/compile_all.py
+++ b/compile_all.py
@@ -29,31 +29,8 @@ _DEBUG_BUILD_EXCLUDED_REQUIREMENTS = frozenset(
         # Direct C/C++/Fortran/Rust extensions with no pure-Python distribution.
         "cmake",
         "cog",
-        # contourpy uses meson-python and looks up pybind11 via pkg-config in its
-        # meson.build. Windows does not ship pkg-config, so the metadata step fails
-        # before we even get to the C++ compile. Reintroducing this package needs a
-        # meson native file or a pkg-config installation. Other meson-python packages
-        # that bypass pkg-config (numpy, scipy) may work without this complication.
-        "contourpy",
-        # kiwisolver 1.5.0 sdist reports project version 0.0.0 from meson, not 1.5.0.
-        # Pip's strict metadata check rejects the mismatch. Reintroducing this package
-        # needs either a downgrade to 1.4.x in config.json or a per-package
-        # --config-settings override of the version at pip invocation time.
-        "kiwisolver",
         "ifcopenshell",
-        "lxml",
-        # Pillow 12.x made libjpeg a required dependency with no env-var or build-flag
-        # escape hatch (the previous "reduced support" path was removed). Reintroducing
-        # this package needs libjpeg-turbo as a LibPack C++ package (build_libjpeg in
-        # compile_all.py and an entry in config.json), or a downgrade to pillow 11.x.
-        "pillow",
-        "pydantic_core",
         "shapely",
-        "watchfiles",
-        # Transitively excluded because their hard dependencies are excluded above.
-        "fastapi",
-        "matplotlib",
-        "pydantic",
     )
 )
 
@@ -75,13 +52,29 @@ _DEBUG_BUILD_REQUIRED_TOOLING = (
     "Cython",
     "pkgconf",
     "pythran",
+    "setuptools_scm",
+    "maturin",
 )
 
 # Packages with C extensions that pip must source-build against the debug Python rather
 # than pull from PyPI as a wheel. Windows Py_DEBUG reports both cp3XXd and cp3XX as
 # compatible platform tags, so without --no-binary pip happily picks a release wheel that
 # then fails to load against python_d.exe at runtime. Names match pip's --no-binary syntax.
-_DEBUG_BUILD_FROM_SOURCE = ("regex", "PyYAML", "httptools", "debugpy", "numpy", "scipy")
+_DEBUG_BUILD_FROM_SOURCE = (
+    "regex",
+    "PyYAML",
+    "httptools",
+    "debugpy",
+    "numpy",
+    "scipy",
+    "contourpy",
+    "kiwisolver",
+    "pillow",
+    "matplotlib",
+    "pydantic_core",
+    "watchfiles",
+    "lxml",
+)
 
 # Sitecustomize shim installed at <libpack>/bin/Lib/site-packages/sitecustomize.py for
 # Debug LibPacks. Setuptools' build_ext defaults debug=False even when the target Python
@@ -107,7 +100,8 @@ import sys
 import sysconfig
 
 if sysconfig.get_config_var("Py_DEBUG"):
-    _patched = False
+    _patched_build_ext = False
+    _patched_msvc = False
     try:
         from setuptools.command.build_ext import build_ext as _build_ext
     except ImportError:
@@ -120,12 +114,40 @@ if sysconfig.get_config_var("Py_DEBUG"):
             self.debug = True
 
         _build_ext.initialize_options = _initialize_options_force_debug
-        _patched = True
-    if not _patched:
+        _patched_build_ext = True
+
+    try:
+        from setuptools._distutils import _msvccompiler as _msvc
+    except ImportError:
+        try:
+            import distutils._msvccompiler as _msvc
+        except ImportError:
+            _msvc = None
+    if _msvc is not None:
+        _orig_msvc_initialize = _msvc.MSVCCompiler.initialize
+
+        def _initialize_with_fs(self, plat_name=None):
+            _orig_msvc_initialize(self, plat_name)
+            # Replace /Zi with /Z7 so debug info is embedded in each .obj rather than
+            # written to a shared per-directory .pdb. /FS via mspdbsrv is the documented
+            # fix for the parallel-build PDB race, but in pip-driven builds (notably
+            # pillow's parallel-compile setup.py) it does not always reach all child
+            # cl.exe instances. /Z7 sidesteps the race entirely by removing the shared
+            # writer. The linker still produces a per-extension .pdb at link time.
+            for options in (self.compile_options_debug, self.compile_options):
+                while "/Zi" in options:
+                    options[options.index("/Zi")] = "/Z7"
+                if "/FS" not in options:
+                    options.append("/FS")
+
+        _msvc.MSVCCompiler.initialize = _initialize_with_fs
+        _patched_msvc = True
+
+    if not (_patched_build_ext and _patched_msvc):
         sys.stderr.write(
-            "WARNING: FreeCAD LibPack sitecustomize could not patch setuptools build_ext "
-            "to enforce Py_DEBUG compilation. C extensions built in this interpreter will "
-            "use the release CRT and may corrupt heap state.\\n"
+            "WARNING: FreeCAD LibPack sitecustomize could not fully patch setuptools/MSVC "
+            "for Py_DEBUG compilation. C extensions built in this interpreter may use "
+            "the release CRT or race on parallel PDB writes.\\n"
         )
 '''
 
@@ -357,6 +379,103 @@ class Compiler:
 
     def build_nonexistent(self, _=None):
         """Used for automated testing to allow easy Mock injection"""
+
+    def build_libiconv(self, _=None):
+        """Build win-iconv, a small Windows-targeted libiconv implementation. Provides
+        iconv.lib for source-built lxml in Debug mode. Skipped entirely in Release mode
+        because PyPI lxml wheels bundle their own iconv."""
+        if self.mode != BuildMode.DEBUG:
+            print("  Skipping libiconv build in Release mode (lxml wheel bundles its own iconv).")
+            return
+        if self.skip_existing:
+            sentinel = os.path.join(self.install_dir, "include", "iconv.h")
+            if os.path.exists(sentinel):
+                print("  Not rebuilding libiconv, it is already in the LibPack")
+                return
+        extra_args = [
+            "-G",
+            "Ninja",
+            "-D BUILD_SHARED_LIBS=ON",
+            "-D BUILD_TEST=OFF",
+        ]
+        self._build_standard_cmake(extra_args=extra_args)
+
+    def build_libxml2(self, _=None):
+        """Build libxml2, providing the XML parser and tree API for source-built lxml in
+        Debug mode. Skipped entirely in Release mode because PyPI lxml wheels bundle
+        their own libxml2.
+
+        Uses the Ninja CMake generator for the same reason as the other Debug-only C
+        packages."""
+        if self.mode != BuildMode.DEBUG:
+            print("  Skipping libxml2 build in Release mode (lxml wheel bundles its own libxml2).")
+            return
+        if self.skip_existing:
+            sentinel = os.path.join(
+                self.install_dir, "include", "libxml2", "libxml", "xmlversion.h"
+            )
+            if os.path.exists(sentinel):
+                print("  Not rebuilding libxml2, it is already in the LibPack")
+                return
+        extra_args = [
+            "-G",
+            "Ninja",
+            "-D BUILD_SHARED_LIBS=ON",
+            "-D LIBXML2_WITH_PYTHON=OFF",
+            "-D LIBXML2_WITH_TESTS=OFF",
+            "-D LIBXML2_WITH_ICONV=OFF",
+            "-D LIBXML2_WITH_LZMA=OFF",
+        ]
+        self._build_standard_cmake(extra_args=extra_args)
+
+    def build_libxslt(self, _=None):
+        """Build libxslt, providing the XSLT engine for source-built lxml in Debug
+        mode. Depends on libxml2 above. Skipped entirely in Release mode because PyPI
+        lxml wheels bundle their own libxslt."""
+        if self.mode != BuildMode.DEBUG:
+            print("  Skipping libxslt build in Release mode (lxml wheel bundles its own libxslt).")
+            return
+        if self.skip_existing:
+            sentinel = os.path.join(self.install_dir, "include", "libxslt", "xslt.h")
+            if os.path.exists(sentinel):
+                print("  Not rebuilding libxslt, it is already in the LibPack")
+                return
+        extra_args = [
+            "-G",
+            "Ninja",
+            "-D BUILD_SHARED_LIBS=ON",
+            "-D LIBXSLT_WITH_PYTHON=OFF",
+            "-D LIBXSLT_WITH_TESTS=OFF",
+        ]
+        self._build_standard_cmake(extra_args=extra_args)
+
+    def build_libjpeg(self, _=None):
+        """Build libjpeg-turbo, providing the libjpeg API for source-built Pillow in
+        Debug mode. Skipped entirely in Release mode because PyPI Pillow wheels bundle
+        their own libjpeg, and nothing else in the Release LibPack consumes libjpeg.
+
+        Uses the Ninja CMake generator for the same reason as OpenBLAS: it sidesteps
+        the v143 PlatformToolset resolution failure that the default Visual Studio
+        generator hits on VS 2026 installs missing the
+        Microsoft.VCToolsVersion.v143.default.props file."""
+        if self.mode != BuildMode.DEBUG:
+            print(
+                "  Skipping libjpeg-turbo build in Release mode (Pillow wheel bundles its own libjpeg)."
+            )
+            return
+        if self.skip_existing:
+            if os.path.exists(os.path.join(self.install_dir, "include", "jpeglib.h")):
+                print("  Not rebuilding libjpeg-turbo, it is already in the LibPack")
+                return
+        extra_args = [
+            "-G",
+            "Ninja",
+            "-D ENABLE_SHARED=ON",
+            "-D ENABLE_STATIC=OFF",
+            "-D WITH_TURBOJPEG=ON",
+            "-D BUILD_TESTING=OFF",
+        ]
+        self._build_standard_cmake(extra_args=extra_args)
 
     def build_openblas(self, _=None):
         """Build OpenBLAS, providing BLAS and LAPACK for source-built numpy and scipy
@@ -656,6 +775,9 @@ class Compiler:
         aliases = (
             ("lib/zd.lib", "lib/zlib.lib"),
             ("lib/libpng16d.lib", "lib/libpng16.lib"),
+            ("lib/libxml2d.lib", "lib/libxml2.lib"),
+            ("lib/libxsltd.lib", "lib/libxslt.lib"),
+            ("lib/libexsltd.lib", "lib/libexslt.lib"),
         )
         for src, dst in aliases:
             src_path = os.path.join(self.install_dir, src)
@@ -697,15 +819,14 @@ class Compiler:
         # linked against VCRUNTIME140.dll. Pass both -Dbuildtype=debug (so meson selects
         # debug compile flags and no NDEBUG) and -Db_vscrt=mdd (so the linker uses
         # ucrtbased.dll and VCRUNTIME140D.dll).
-        # blas=openblas / lapack=openblas point numpy at the LibPack-built OpenBLAS;
-        # meson's dependency() finds it via pkg-config (PKG_CONFIG_PATH) or CMake
-        # (CMAKE_PREFIX_PATH), both set in the subprocess env above.
+        # No explicit blas / lapack option here: numpy and scipy auto-detect OpenBLAS
+        # via the openblas.pc that pkg-config sees through PKG_CONFIG_PATH set in the
+        # subprocess env below. Most other meson-python projects (contourpy, etc.) do
+        # not declare a blas option and would error if we passed one.
         config_settings = (
             (
                 ("setup-args", "-Dbuildtype=debug"),
                 ("setup-args", "-Db_vscrt=mdd"),
-                ("setup-args", "-Dblas=openblas"),
-                ("setup-args", "-Dlapack=openblas"),
                 # cpp_std=c++17 is required for pythran-generated C++ in scipy. Pythran's
                 # generated headers still use std::result_of_t, which C++20 removed.
                 # MSVC's default standard is newer than C++17 in current toolsets, so we
@@ -774,6 +895,28 @@ class Compiler:
             env = os.environ.copy()
             env["DISTUTILS_USE_SDK"] = "1"
             env["MSSdk"] = "1"
+            # kiwisolver's pyproject.toml declares dynamic version via setuptools_scm,
+            # which falls back to "0.0.0" outside a git checkout. Pip's metadata
+            # consistency check then rejects the sdist (requested 1.5.0, got 0.0.0).
+            # The setuptools_scm-native override is package-scoped by name suffix,
+            # so it does not affect any other setuptools_scm packages we install.
+            env["SETUPTOOLS_SCM_PRETEND_VERSION_FOR_KIWISOLVER"] = "1.5.0"
+            # lxml on Windows defaults to STATIC_DEPS=true, which downloads
+            # libxml2/libxslt sources and bundles them statically. We provide both
+            # as LibPack packages with pkg-config files (libxml-2.0.pc, libxslt.pc).
+            # STATIC_DEPS=false switches lxml to the system-deps path; pkg-config
+            # then supplies the correct -I${includedir}/libxml2 cflag that lxml's
+            # source needs to find <libxml/xmlversion.h>.
+            env["STATIC_DEPS"] = "false"
+            # pkgconf-pypi 2.5.x has a bug in its pkg-config.exe wrapper: when
+            # PKG_CONFIG_PATH is set in the environment, the wrapper's
+            # _vanilla_entrypoint never invokes the bundled pkgconf binary at all
+            # and exits 0 with no output. FORCE_PKGCONF_PYPI=1 routes the wrapper
+            # through _python_aware_entrypoint which calls pkgconf correctly. lxml
+            # is the first package whose setup.py invokes pkg-config at build time;
+            # without this, pkg-config silently returns no flags and lxml's compile
+            # cannot find <libxml/xmlversion.h>.
+            env["FORCE_PKGCONF_PYPI"] = "1"
             scripts_dir = os.path.join(self.install_dir, "bin", "Scripts")
             bin_dir = os.path.join(self.install_dir, "bin")
             env["PATH"] = scripts_dir + os.pathsep + bin_dir + os.pathsep + env.get("PATH", "")
@@ -789,8 +932,15 @@ class Compiler:
             # dependency() resolves OpenBLAS (and any future LibPack-bundled lib) by either
             # method. pkg-config is the preferred lookup for numpy and scipy; CMake is the
             # fallback meson tries when pkg-config does not find a match.
-            pkgconfig_dir = os.path.join(self.install_dir, "lib", "pkgconfig")
-            env["PKG_CONFIG_PATH"] = pkgconfig_dir + os.pathsep + env.get("PKG_CONFIG_PATH", "")
+            pkgconfig_lib_dir = os.path.join(self.install_dir, "lib", "pkgconfig")
+            pkgconfig_share_dir = os.path.join(self.install_dir, "share", "pkgconfig")
+            env["PKG_CONFIG_PATH"] = (
+                pkgconfig_lib_dir
+                + os.pathsep
+                + pkgconfig_share_dir
+                + os.pathsep
+                + env.get("PKG_CONFIG_PATH", "")
+            )
             env["CMAKE_PREFIX_PATH"] = (
                 self.install_dir + os.pathsep + env.get("CMAKE_PREFIX_PATH", "")
             )
@@ -1695,9 +1845,14 @@ class Compiler:
         self._build_standard_cmake(extra_args)
 
     def build_ifcopenshell(self, _=None):
-        """On x64 Windows ifcopenshell is installed via pip from PyPI. On ARM64 Windows no
-        PyPI wheel exists, so the working directory is populated from the prebuilt zip at
-        builds.ifcopenshell.org and the package directory is copied into site-packages."""
+        """In Release mode: x64 Windows installs from PyPI; ARM64 Windows extracts a
+        prebuilt zip from builds.ifcopenshell.org into site-packages.
+
+        In Debug mode: neither PyPI wheel nor S3 prebuilt has cp3XXd ABI artifacts, so
+        we source-build from the upstream GitHub repo using LibPack Boost, OpenCASCADE,
+        libxml2, and HDF5."""
+        if self.mode == BuildMode.DEBUG:
+            return self._build_ifcopenshell_debug()
         if platform.machine() != "ARM64" or sys.platform != "win32":
             return
         site_packages = os.path.join(self.install_dir, "bin", "Lib", "site-packages")
@@ -1713,3 +1868,77 @@ class Compiler:
         if os.path.exists(target):
             shutil.rmtree(target, onerror=remove_readonly)
         shutil.copytree(source, target)
+
+    def _build_ifcopenshell_debug(self):
+        """Debug-mode source build of IfcOpenShell. fetch_remote_data clones and
+        patches the source for us in Debug because the ifcopenshell entry has
+        both a git-repo and a url-ARM64 (the latter is the Release-only prebuilt
+        zip)."""
+        site_packages = os.path.join(self.install_dir, "bin", "Lib", "site-packages")
+        target = os.path.join(site_packages, "ifcopenshell")
+        if self.skip_existing and os.path.exists(target):
+            print("  Not rebuilding ifcopenshell, it is already in the LibPack")
+            return
+        cwd = os.getcwd()
+        # IfcOpenShell's root CMakeLists.txt lives in the cmake/ subdirectory, not
+        # the repo root. Dependencies (OpenCASCADE, HDF5, LibXml2, VTK) are resolved
+        # through their installed CMake package configs via CMAKE_PREFIX_PATH rather
+        # than passing manual include and library paths, because OCCT installs into a
+        # flat layout (inc/ and libd/) that does not match the conventional layout
+        # IfcOpenShell's Find modules assume.
+        ifc_install_dir = self.install_dir.replace("\\", "/")
+        extra_args = [
+            "-G",
+            "Ninja",
+            "-D CMAKE_CXX_STANDARD=17",
+            f"-D CMAKE_PREFIX_PATH={ifc_install_dir}",
+            f"-D BOOST_ROOT={ifc_install_dir}",
+            "-D Boost_USE_STATIC_LIBS=OFF",
+            f"-D HDF5_DIR={ifc_install_dir}/cmake",
+            f"-D PYTHON_EXECUTABLE={self.python_exe()}",
+            "-D BUILD_IFCPYTHON=ON",
+            "-D BUILD_IFCMAX=OFF",
+            "-D BUILD_GEOMSERVER=OFF",
+            "-D BUILD_CONVERT=OFF",
+            "-D BUILD_EXAMPLES=OFF",
+            "-D BUILD_TESTING=OFF",
+            "-D WITH_CGAL=OFF",
+            "-D COLLADA_SUPPORT=OFF",
+            "-D HDF5_SUPPORT=OFF",
+            "-D USE_DEBUG_PYTHON=ON",
+            "-D BUILD_ONLY_COMMON_SCHEMAS=ON",
+            "-D BUILD_SHARED_LIBS=OFF",
+        ]
+        # The source layout puts the CMakeLists in cmake/, not the repo root, so we
+        # cannot use the standard _build_standard_cmake helper which assumes "..".
+        build_dir = os.path.join(cwd, "build-debug")
+        if os.path.exists(build_dir):
+            shutil.rmtree(build_dir, onerror=remove_readonly)
+        os.makedirs(build_dir)
+        os.chdir(build_dir)
+        # IfcOpenShell's CMakeLists.txt and svgfill/CMakeLists.txt both contain
+        # blocks guarded by `if(WIN32 AND NOT DEFINED ENV{CONDA_BUILD})` that force
+        # `Boost_USE_STATIC_LIBS=ON` as a non-cache variable, which shadows any -D
+        # we pass and causes Boost's modular shared configs to declare themselves
+        # version-incompatible. FindHDF5.cmake similarly takes a Windows naming
+        # path that does not match our LibPack when CONDA_BUILD is unset. Setting
+        # CONDA_BUILD diverts all three sites to the branch that uses the package
+        # configs we install, with no other side effects in IfcOpenShell.
+        prev_conda_build = os.environ.get("CONDA_BUILD")
+        os.environ["CONDA_BUILD"] = "1"
+        old_strict_mode = self.strict_mode
+        self.strict_mode = False
+        try:
+            options = self.get_cmake_options()
+            options.extend(extra_args)
+            options.append("../cmake")
+            self._run_cmake(options)
+            self._cmake_build()
+            self._cmake_install()
+        finally:
+            self.strict_mode = old_strict_mode
+            if prev_conda_build is None:
+                os.environ.pop("CONDA_BUILD", None)
+            else:
+                os.environ["CONDA_BUILD"] = prev_conda_build
+            os.chdir(cwd)

--- a/compile_all.py
+++ b/compile_all.py
@@ -18,6 +18,52 @@ import subprocess
 import stat
 import sys
 
+# Pip requirements skipped in Debug mode because their PyPI distribution is a release-ABI
+# wheel (cp3XX) that cannot install against the Py_DEBUG (cp3XXd) interpreter. These will
+# be source-built against the debug Python in a later phase (debug_build_plan.md Phase 3).
+# Names are matched case-insensitively against the package portion of each requirement
+# specifier in config.json. Trim this set as each package gains a working source-build.
+_DEBUG_BUILD_EXCLUDED_REQUIREMENTS = frozenset(
+    name.lower()
+    for name in (
+        # Direct C/C++/Fortran/Rust extensions with no pure-Python distribution.
+        "cmake",
+        "cog",
+        "contourpy",
+        "debugpy",
+        "httptools",
+        "ifcopenshell",
+        "kiwisolver",
+        "lxml",
+        "numpy",
+        "pillow",
+        "pydantic_core",
+        "PyYAML",
+        "regex",
+        "shapely",
+        "watchfiles",
+        # Transitively excluded because their hard dependencies are excluded above.
+        "fastapi",
+        "matplotlib",
+        "nltk",
+        "pycollada",
+        "pydantic",
+        "scipy",
+    )
+)
+
+# Build-time pure-Python tooling that must be present even when the rest of the requirements
+# list is skipped. setup.py-based packages built later in the LibPack (PySide, opencamlib)
+# import these at build time.
+_DEBUG_BUILD_REQUIRED_TOOLING = ("packaging", "setuptools", "wheel")
+
+
+def _requirement_package_name(spec: str) -> str:
+    """Extract the lowercased package name from a pip requirement specifier such as
+    'numpy==2.4.4' or 'shapely==2.1.2; platform_machine != "ARM64"'."""
+    match = re.match(r"\s*([A-Za-z0-9_.-]+)", spec)
+    return match.group(1).lower() if match else ""
+
 
 class BuildMode(Enum):
     DEBUG = 1
@@ -461,13 +507,21 @@ class Compiler:
                 print(e.output.decode("utf-8", errors="replace"))
             exit(1)
 
+    def _filter_debug_requirements(self, requirements):
+        kept = [
+            spec
+            for spec in requirements
+            if _requirement_package_name(spec) not in _DEBUG_BUILD_EXCLUDED_REQUIREMENTS
+        ]
+        kept_names = {_requirement_package_name(spec) for spec in kept}
+        for tool in _DEBUG_BUILD_REQUIRED_TOOLING:
+            if tool.lower() not in kept_names:
+                kept.append(tool)
+        return kept
+
     def _install_python_requirements(self, requirements):
         if self.mode == BuildMode.DEBUG:
-            # PyPI wheels are tagged cp3XX and cannot install against Py_DEBUG (cp3XXd).
-            # For now, install only pure-Python tooling that setup.py-based packages need at build
-            # time later in the LibPack (PySide, opencamlib, and so on). Once I get this working as
-            # far as it can, I'll start actually compiling the debug wheels.
-            requirements = ["packaging", "setuptools", "wheel"]
+            requirements = self._filter_debug_requirements(requirements)
         sentinel = "packaging" if self.mode == BuildMode.DEBUG else "PIL"
         if self.skip_existing:
             if os.path.exists(

--- a/config.json
+++ b/config.json
@@ -3,6 +3,15 @@
     "LibPack-version":"3.4.0",
     "content": [
         {
+            "name":"openblas",
+            "git-repo":"https://github.com/OpenMathLib/OpenBLAS",
+            "git-ref":"v0.3.28",
+            "patches": [
+                "patches/openblas-01-honor-build-testing.patch"
+            ],
+            "note": "Debug-only package. In Release mode build_openblas returns early because PyPI numpy and scipy wheels bundle their own OpenBLAS in numpy/.libs/. In Debug mode this provides the BLAS+LAPACK that source-built numpy and scipy link against."
+        },
+        {
             "name":"python",
             "git-repo":"https://github.com/python/cpython.git",
             "git-ref":"v3.14.4",

--- a/config.json
+++ b/config.json
@@ -195,7 +195,8 @@
             "git-repo":"https://github.com/NGSolve/netgen",
             "git-ref":"v6.2.2604",
             "patches":[
-                "patches/netgen-02-arm64-msvc-time-counter.patch"
+                "patches/netgen-02-arm64-msvc-time-counter.patch",
+                "patches/netgen-03-msvc-runtime-debug-aware.patch"
             ]
         },
         {

--- a/config.json
+++ b/config.json
@@ -196,7 +196,8 @@
             "git-ref":"v6.2.2604",
             "patches":[
                 "patches/netgen-02-arm64-msvc-time-counter.patch",
-                "patches/netgen-03-msvc-runtime-debug-aware.patch"
+                "patches/netgen-03-msvc-runtime-debug-aware.patch",
+                "patches/netgen-04-tbitarray-or-inline-no-export.patch"
             ]
         },
         {

--- a/config.json
+++ b/config.json
@@ -3,6 +3,30 @@
     "LibPack-version":"3.4.0",
     "content": [
         {
+            "name":"libiconv",
+            "git-repo":"https://github.com/win-iconv/win-iconv",
+            "git-ref":"v0.0.8",
+            "note": "Debug-only package. lxml's setup.py hardcodes 'iconv' in its Windows link line regardless of STATIC_DEPS or libxml2 configuration. We disable iconv in libxml2 (LIBXML2_WITH_ICONV=OFF) so nothing actually calls iconv functions, but lxml still requires iconv.lib at link time. win-iconv is a small Windows-targeted implementation that satisfies the link without bloat. Release uses lxml's PyPI wheel which bundles iconv internally."
+        },
+        {
+            "name":"libxml2",
+            "git-repo":"https://github.com/GNOME/libxml2",
+            "git-ref":"v2.13.5",
+            "note": "Debug-only package. Source-built so that lxml has a libxml2 to link against under Py_DEBUG. Release uses lxml's PyPI wheel which bundles libxml2 internally."
+        },
+        {
+            "name":"libxslt",
+            "git-repo":"https://github.com/GNOME/libxslt",
+            "git-ref":"v1.1.42",
+            "note": "Debug-only package. Depends on libxml2 above. Release uses lxml's bundled libxslt."
+        },
+        {
+            "name":"libjpeg",
+            "git-repo":"https://github.com/libjpeg-turbo/libjpeg-turbo",
+            "git-ref":"3.0.4",
+            "note": "Debug-only package. In Release mode build_libjpeg returns early because PyPI Pillow wheels bundle their own libjpeg. In Debug mode this provides the libjpeg API that source-built Pillow links against."
+        },
+        {
             "name":"openblas",
             "git-repo":"https://github.com/OpenMathLib/OpenBLAS",
             "git-ref":"v0.3.28",
@@ -275,8 +299,15 @@
         },
         {
             "name": "ifcopenshell",
+            "git-repo": "https://github.com/IfcOpenShell/IfcOpenShell.git",
+            "git-ref": "ifcopenshell-python-0.8.5",
             "url-ARM64": "https://s3.amazonaws.com/ifcopenshell-builds/ifcopenshell-python-314-v0.8.5-18c035e-win-arm64.zip",
-            "note": "x64 is installed via pip from PyPI; ARM64 has no PyPI wheel, so we extract the prebuilt zip from builds.ifcopenshell.org. Both architectures are pinned to v0.8.5."
+            "patches": [
+                "patches/ifcopenshell-01-disable-permissive.patch",
+                "patches/ifcopenshell-02-profile-point-msvc-fix.patch",
+                "patches/ifcopenshell-03-opaquecoordinate-sfinae.patch"
+            ],
+            "note": "Release x64 is installed via pip from PyPI and ignores both source and zip. Release ARM64 has no PyPI wheel, so we extract the prebuilt zip from builds.ifcopenshell.org. Debug source-builds from the GitHub clone because no prebuilt cp314d artifact exists. fetch_remote_data treats this hybrid entry as: clone in Debug, download zip in Release on ARM64, do nothing in Release on x64. Patches only apply on the clone path, so the prebuilt zip is left untouched. All three paths target v0.8.5."
         }
     ]
 }

--- a/create_libpack.py
+++ b/create_libpack.py
@@ -510,6 +510,7 @@ if __name__ == "__main__":
         path_cleaner.delete_documentation(base_path)
         path_cleaner.delete_occt_sample_data(base_path)
         path_cleaner.delete_python_test_suites(base_path)
-        path_cleaner.delete_pdb_files(base_path)
+        if mode == compile_all.BuildMode.RELEASE:
+            path_cleaner.delete_pdb_files(base_path)
 
         write_manifest(config_dict, mode)

--- a/create_libpack.py
+++ b/create_libpack.py
@@ -511,6 +511,13 @@ if __name__ == "__main__":
 
         # Final cleanup: delete extraneous files and remove local path references from the cMake files
         base_path = compile_all.libpack_dir(config_dict, mode)
+        if mode == compile_all.BuildMode.DEBUG:
+            extra_pdb_search_dirs = [
+                item["fallback-build-dir"]
+                for item in config_dict.get("content", [])
+                if "fallback-build-dir" in item
+            ]
+            path_cleaner.install_pdb_sidecars(base_path, os.getcwd(), extra_pdb_search_dirs)
         path_cleaner.delete_extraneous_files(base_path)
         path_cleaner.remove_local_path_from_cmake_files(base_path)
         path_cleaner.correct_opencascade_freetype_ref(base_path)

--- a/create_libpack.py
+++ b/create_libpack.py
@@ -115,36 +115,51 @@ def create_libpack_dir(config: dict, mode: compile_all.BuildMode) -> str:
     return dirname
 
 
-def fetch_remote_data(config: dict, skip_existing: bool = False):
-    """Clone the required repos and download the URLs"""
+def _select_url(item: dict) -> str | None:
+    if "url" in item:
+        return item["url"]
+    if platform.machine() == "ARM64" and "url-ARM64" in item:
+        return item["url-ARM64"]
+    if "url-x64" in item:
+        return item["url-x64"]
+    return None
+
+
+def fetch_remote_data(config: dict, mode: compile_all.BuildMode, skip_existing: bool = False):
+    """Clone the required repos and download the URLs.
+
+    Entries that provide both a `git-repo` and a `url-*` are treated as hybrid:
+    Debug builds clone the source (so the package can be built locally against
+    the Py_DEBUG ABI), Release builds prefer the prebuilt URL, and if no URL
+    matches the current architecture nothing is fetched (the build step is
+    expected to handle the package some other way, e.g. via pip)."""
     content = config["content"]
+    is_debug = mode == compile_all.BuildMode.DEBUG
     for item in content:
         if skip_existing and os.path.exists(item["name"]):
             continue
-        if "git-repo" in item:
+        has_git = "git-repo" in item
+        has_any_url = any(k in item for k in ("url", "url-ARM64", "url-x64"))
+        url = _select_url(item)
+        if ("git-ref" in item or "git-hash" in item) and not has_git:
+            print(f"ERROR: found a git ref/hash without a git repo for {item['name']}")
+            exit()
+        if has_git and (not has_any_url or is_debug):
             clone(
                 item["name"],
                 item["git-repo"],
-                item["git-ref"] if "git-ref" in item else None,
-                item["git-hash"] if "git-hash" in item else None,
+                item.get("git-ref"),
+                item.get("git-hash"),
             )
-        elif "git-ref" in item or "git-hash" in item:
-            print(f"ERROR: found a git ref/hash without a git repo for {item['name']}")
-            exit()
-        elif "url" in item:
-            download(item["name"], item["url"])
-        elif "url-ARM64" in item and platform.machine() == "ARM64":
-            download(item["name"], item["url-ARM64"])
-        elif "url-x64" in item and platform.machine() == "AMD64":
-            download(item["name"], item["url-x64"])
+            if "patches" in item:
+                cwd = os.getcwd()
+                os.chdir(item["name"])
+                compile_all.patch_files(item["patches"])
+                os.chdir(cwd)
+        elif url is not None:
+            download(item["name"], url)
         else:
-            # Just make the directory, presumably later code will know what to do
             os.makedirs(item["name"], exist_ok=True)
-        if "patches" in item:
-            cwd = os.getcwd()
-            os.chdir(item["name"])
-            compile_all.patch_files(item["patches"])
-            os.chdir(cwd)
 
 
 def clone(name: str, url: str, ref: str = None, hash: str = None):
@@ -447,7 +462,7 @@ if __name__ == "__main__":
     else:
         base = create_libpack_dir(config_dict, mode)
     with prevent_sleep_mode():
-        fetch_remote_data(config_dict, args["no_skip_existing_clone"])
+        fetch_remote_data(config_dict, mode, args["no_skip_existing_clone"])
 
         compiler = compile_all.Compiler(
             config_dict,

--- a/patches/ifcopenshell-01-disable-permissive.patch
+++ b/patches/ifcopenshell-01-disable-permissive.patch
@@ -1,0 +1,9 @@
+@@@ cmake/CMakeLists.txt @@@
+@@ -17784,32 +17784,34 @@
+ TER 66))%0A       
++ #
+  add_definitions
+@@ -17824,16 +17824,46 @@
+ issive-)
++ # disabled by FreeCAD LibPack
+ %0A    end

--- a/patches/ifcopenshell-02-profile-point-msvc-fix.patch
+++ b/patches/ifcopenshell-02-profile-point-msvc-fix.patch
@@ -1,0 +1,22 @@
+@@@ src/ifcgeom/profile_helper.h @@@
+@@ -67,16 +67,37 @@
+ omy.h%22%0A%0A
++#include %3Coptional%3E%0A%0A
+ namespac
+@@ -197,167 +197,37 @@
+ %0A%09%09%09
+-boost::optional%3Cdouble%3E radius;%0A%0A%09%09%09profile_point(const std::array%3Cdouble, 2%3E& p, const boost::optional%3Cdouble%3E& r = boost::none)%0A%09%09%09%09: xy(p), radius(r) %7B%0A%09%09%09%7D
++std::optional%3Cdouble%3E radius;
+ %0A%09%09%7D
+@@ -283,37 +283,35 @@
+ Vector2d xy;%0A%09%09%09
+-boo
+ st
++d
+ ::optional%3Cdoubl
+@@ -435,13 +435,11 @@
+ %0A%09%09%09
+-boo
+ st
++d
+ ::op

--- a/patches/ifcopenshell-03-opaquecoordinate-sfinae.patch
+++ b/patches/ifcopenshell-03-opaquecoordinate-sfinae.patch
@@ -1,0 +1,16 @@
+@@@ src/ifcgeom/ConversionResult.h @@@
+@@ -5868,62 +5868,38 @@
+ Args
+-%3E%0A%09%09OpaqueCoordinate(Args... args) %7B%0A%09%09%09static_assert(
++, typename = std::enable_if_t%3C
+ size
+@@ -5904,17 +5904,17 @@
+ zeof...(
+-a
++A
+ rgs) == 
+@@ -5918,52 +5918,45 @@
+ == N
+-, %22Incorrect number of arguments provided%22);
++%3E%3E%0A%09%09OpaqueCoordinate(Args... args) %7B
+ %0A%09%09%09

--- a/patches/netgen-03-msvc-runtime-debug-aware.patch
+++ b/patches/netgen-03-msvc-runtime-debug-aware.patch
@@ -1,0 +1,5 @@
+@@@ CMakeLists.txt @@@
+@@ -157,16 +157,40 @@
+ Threaded
++$%3C$%3CCONFIG:Debug%3E:Debug%3E
+ DLL%22)%0A%0Ac

--- a/patches/netgen-04-tbitarray-or-inline-no-export.patch
+++ b/patches/netgen-04-tbitarray-or-inline-no-export.patch
@@ -1,0 +1,5 @@
+@@@ libsrc/core/bitarray.hpp @@@
+@@ -5141,27 +5141,16 @@
+ ; %7D%0A    
+-NGCORE_API 
+ TBitArra

--- a/patches/openblas-01-honor-build-testing.patch
+++ b/patches/openblas-01-honor-build-testing.patch
@@ -1,0 +1,13 @@
+@@@ CMakeLists.txt @@@
+@@ -12834,24 +12834,42 @@
+ ORTRAN)%0Aif (
++BUILD_TESTING AND 
+ NOT NO_CBLAS
+@@ -12972,24 +12972,42 @@
+ ndif()%0A%0Aif (
++BUILD_TESTING AND 
+ NOT NOFORTRA
+@@ -13205,16 +13205,34 @@
+ ()%0A  if(
++BUILD_TESTING AND 
+ NOT NO_C

--- a/path_cleaner.py
+++ b/path_cleaner.py
@@ -7,7 +7,9 @@
 # should probably be consolidated.
 
 import os
+import re
 import shutil
+from typing import Dict, List
 
 paths_to_delete = [
     "custom_vc14_64.bat",
@@ -69,8 +71,29 @@ def remove_local_path_from_cmake_file(base_path: str, file_to_clean: str) -> Non
     if cmake_base_path != base_path_native:
         contents = contents.replace(cmake_base_path, cmake_replacement)
 
+    contents = _normalize_slashes_in_cmake_paths(contents)
+
     with open(file_to_clean, "w", encoding="utf-8") as f:
         f.write(contents)
+
+
+_QUOTED_CMAKE_PATH_RE = re.compile(r'"([^"\n]*\$\{CMAKE_CURRENT_SOURCE_DIR\}[^"\n]*)"')
+
+
+def _normalize_slashes_in_cmake_paths(contents: str) -> str:
+    """Some upstreams (Netgen, others) record Windows-style paths with backslashes
+    in their installed CMake configs. After the prefix substitution above, the
+    install-dir portion is replaced with `${CMAKE_CURRENT_SOURCE_DIR}/...` but any
+    trailing backslashes inside the quoted string remain, producing strings such
+    as `"${CMAKE_CURRENT_SOURCE_DIR}/..\\bin\\python_d.exe"`. CMake accepts
+    forward slashes universally on Windows; quoted strings that contain a
+    `${CMAKE_CURRENT_SOURCE_DIR}` reference are paths, not CMake escape sequences,
+    so it is safe to normalize backslashes within them."""
+
+    def _normalize(match: re.Match) -> str:
+        return '"' + match.group(1).replace("\\", "/") + '"'
+
+    return _QUOTED_CMAKE_PATH_RE.sub(_normalize, contents)
 
 
 def create_depth_string(base_path: str, file_to_clean: str) -> str:
@@ -354,6 +377,80 @@ def delete_llvm_internal_headers(base_path: str) -> int:
         except OSError as e:
             print(f"Failed to delete {target}: {e}")
     return removed
+
+
+_VC_INTERMEDIATE_PDB_RE = re.compile(r"^vc\d+\.pdb$", re.IGNORECASE)
+
+
+def install_pdb_sidecars(
+    install_dir: str, working_dir: str, extra_search_dirs: List[str] = None
+) -> int:
+    """Copy upstream debug-symbol files (PDBs) next to their installed DLLs.
+
+    Most upstream CMake configs install only the DLL and the import library and
+    leave the sidecar PDB behind in the build tree. As a result the installed
+    LibPack carries no debugging information for Qt, OCCT, Coin, VTK, Boost, or
+    the Python interpreter, even when built with /Zi /DEBUG. This walk fills
+    that gap: for every DLL already installed under ``install_dir``, locate a
+    PDB whose stem matches anywhere under ``working_dir`` (or any of the
+    ``extra_search_dirs``) and whose modification time is newest, then copy it
+    next to the DLL. Intermediate cl.exe PDBs (``vcNNN.pdb``) are skipped
+    because they describe per-build compilations rather than a target's debug
+    info. The ``extra_search_dirs`` argument exists because some packages
+    (Qt in particular) build into an out-of-tree ``fallback-build-dir`` to dodge
+    Windows path-length limits, and their PDBs are therefore not under
+    ``working_dir``.
+
+    Returns the number of PDB files newly placed."""
+    print("Installing PDB debug-symbol sidecars")
+    installed_dlls: Dict[str, str] = {}
+    for root, _dirs, files in os.walk(install_dir):
+        for name in files:
+            if name.lower().endswith(".dll"):
+                stem = os.path.splitext(name)[0].lower()
+                installed_dlls.setdefault(stem, os.path.join(root, name))
+
+    install_norm = os.path.normcase(os.path.abspath(install_dir))
+    pdb_index: Dict[str, str] = {}
+    search_roots = [working_dir]
+    if extra_search_dirs:
+        search_roots.extend(extra_search_dirs)
+    for search_root in search_roots:
+        if not os.path.isdir(search_root):
+            continue
+        for root, _dirs, files in os.walk(search_root):
+            if os.path.normcase(os.path.abspath(root)).startswith(install_norm):
+                continue
+            for name in files:
+                if not name.lower().endswith(".pdb"):
+                    continue
+                if _VC_INTERMEDIATE_PDB_RE.match(name):
+                    continue
+                stem = os.path.splitext(name)[0].lower()
+                full = os.path.join(root, name)
+                existing = pdb_index.get(stem)
+                if existing is None or os.path.getmtime(full) > os.path.getmtime(existing):
+                    pdb_index[stem] = full
+
+    copied = 0
+    for stem, dll_install_path in installed_dlls.items():
+        pdb_source = pdb_index.get(stem)
+        if pdb_source is None and stem.endswith("d"):
+            # OpenCASCADE names its debug DLLs with a `d` suffix (e.g. TKerneld.dll)
+            # but emits PDBs without it (TKernel.pdb). Try the stripped stem too.
+            pdb_source = pdb_index.get(stem[:-1])
+        if pdb_source is None:
+            continue
+        pdb_dest = os.path.splitext(dll_install_path)[0] + ".pdb"
+        if os.path.exists(pdb_dest):
+            continue
+        try:
+            shutil.copy2(pdb_source, pdb_dest)
+            copied += 1
+        except OSError as e:
+            print(f"Failed to copy {pdb_source} to {pdb_dest}: {e}")
+    print(f"  Installed {copied} PDB sidecars")
+    return copied
 
 
 def delete_pdb_files(base_path: str) -> int:

--- a/test_create_libpack.py
+++ b/test_create_libpack.py
@@ -10,6 +10,7 @@ import unittest
 from unittest.mock import MagicMock, patch, mock_open
 
 import create_libpack
+from compile_all import BuildMode
 
 
 class TestDeleteExisting(unittest.TestCase):
@@ -125,7 +126,7 @@ class TestRemoteFetchFunctions(unittest.TestCase):
                 {"name": "test3", "git-repo": "test3_repo", "git-ref": "test3_ref"},
             ]
         }
-        create_libpack.fetch_remote_data(test_config)
+        create_libpack.fetch_remote_data(test_config, BuildMode.RELEASE)
         self.assertEqual(mock_clone.call_count, 3)
 
     @patch("builtins.print")
@@ -133,7 +134,7 @@ class TestRemoteFetchFunctions(unittest.TestCase):
         """An entry with a git-ref but no git-repo is an error"""
         test_config = {"content": [{"name": "test1", "git-ref": "test1_ref"}]}
         with self.assertRaises(SystemExit):
-            create_libpack.fetch_remote_data(test_config)
+            create_libpack.fetch_remote_data(test_config, BuildMode.RELEASE)
         mock_print.assert_called()
 
     @patch("create_libpack.clone")
@@ -144,7 +145,7 @@ class TestRemoteFetchFunctions(unittest.TestCase):
                 {"name": "test1", "git-repo": "test1_repo"},
             ]
         }
-        create_libpack.fetch_remote_data(test_config)
+        create_libpack.fetch_remote_data(test_config, BuildMode.RELEASE)
         mock_clone.assert_called_once_with("test1", "test1_repo", None, None)
 
     @patch("create_libpack.clone")
@@ -155,8 +156,46 @@ class TestRemoteFetchFunctions(unittest.TestCase):
                 {"name": "test1"},
             ]
         }
-        create_libpack.fetch_remote_data(test_config)
+        create_libpack.fetch_remote_data(test_config, BuildMode.RELEASE)
         mock_clone.assert_not_called()
+
+    @patch("create_libpack.clone")
+    @patch("create_libpack.download")
+    def test_hybrid_entry_clones_in_debug(self, download_mock: MagicMock, clone_mock: MagicMock):
+        """An entry with both git-repo and url-* is cloned in Debug, downloaded
+        (or skipped) in Release."""
+        test_config = {
+            "content": [
+                {
+                    "name": "hybrid",
+                    "git-repo": "hybrid_repo",
+                    "git-ref": "hybrid_ref",
+                    "url": "https://example.com/prebuilt.zip",
+                }
+            ]
+        }
+        create_libpack.fetch_remote_data(test_config, BuildMode.DEBUG)
+        clone_mock.assert_called_once_with("hybrid", "hybrid_repo", "hybrid_ref", None)
+        download_mock.assert_not_called()
+
+    @patch("create_libpack.clone")
+    @patch("create_libpack.download")
+    def test_hybrid_entry_downloads_in_release(
+        self, download_mock: MagicMock, clone_mock: MagicMock
+    ):
+        test_config = {
+            "content": [
+                {
+                    "name": "hybrid",
+                    "git-repo": "hybrid_repo",
+                    "git-ref": "hybrid_ref",
+                    "url": "https://example.com/prebuilt.zip",
+                }
+            ]
+        }
+        create_libpack.fetch_remote_data(test_config, BuildMode.RELEASE)
+        download_mock.assert_called_once_with("hybrid", "https://example.com/prebuilt.zip")
+        clone_mock.assert_not_called()
 
     @patch("os.chdir")
     @patch("subprocess.run")
@@ -225,13 +264,13 @@ class TestRemoteFetchFunctions(unittest.TestCase):
                 {"name": "test3", "git-repo": "test3_repo", "git-ref": "test3_ref"},
             ]
         }
-        create_libpack.fetch_remote_data(test_config, skip_existing=True)
+        create_libpack.fetch_remote_data(test_config, BuildMode.RELEASE, skip_existing=True)
         clone_mock.assert_not_called()
 
     @patch("create_libpack.download")
     def test_url_calls_download(self, download_mock: MagicMock):
         test_config = {"content": [{"name": "test", "url": "https://some.url"}]}
-        create_libpack.fetch_remote_data(test_config)
+        create_libpack.fetch_remote_data(test_config, BuildMode.RELEASE)
         download_mock.assert_called_once()
 
     @patch("os.mkdir")  # Patch so it doesn't actually make a directory


### PR DESCRIPTION
Add the (extensive) code necessary to compile the LibPack in Debug mode. This is a top-to-bottom Debug build, including source builds of all Python packages, Python itself, Qt, etc. The debug zip is very large (~1.3 GB).

Fixes #22