### PR TITLE
Remove libclang's bundled CPython

### DIFF
--- a/compile_all.py
+++ b/compile_all.py
@@ -1498,7 +1498,19 @@ class Compiler:
                 print("  Not copying libclang, it is already in the LibPack")
                 return
         print("  (not really building libclang, just copying from a build provided by Qt)")
-        shutil.copytree("libclang", self.install_dir, dirs_exist_ok=True)
+
+        # Skip libclang's bundled CPython (bin/python3XX.dll and python3XX.zip), which would
+        # otherwise clobber the LibPack's own Python and shadow its stdlib.
+        def ignore_bundled_python(directory, names):
+            return [
+                name
+                for name in names
+                if re.fullmatch(r"python\w*\.(dll|zip|exe|pdb)", name, re.IGNORECASE)
+            ]
+
+        shutil.copytree(
+            "libclang", self.install_dir, dirs_exist_ok=True, ignore=ignore_bundled_python
+        )
 
     def build_pyside(self, _=None):
         # Don't use a pip-install for this, we need the linkable libraries and include files for both PySide and

--- a/create_libpack.py
+++ b/create_libpack.py
@@ -682,6 +682,7 @@ if __name__ == "__main__":
         path_cleaner.delete_llvm_executables(base_path)
         path_cleaner.delete_clang_executables(base_path)
         path_cleaner.delete_unused_static_libs(base_path)
+        path_cleaner.delete_llvm_cmake_packages(base_path)
         path_cleaner.delete_lldb(base_path)
         path_cleaner.delete_bundled_cmake(base_path)
         path_cleaner.delete_llvm_internal_headers(base_path)

--- a/path_cleaner.py
+++ b/path_cleaner.py
@@ -262,6 +262,34 @@ def delete_unused_static_libs(base_path: str) -> int:
     return removed
 
 
+_ORPHANED_LLVM_CMAKE_DIRS = ("llvm", "clang", "lld")
+
+
+def delete_llvm_cmake_packages(base_path: str) -> int:
+    """Remove the LLVM, Clang, and LLD CMake package directories from lib/cmake/.
+
+    delete_unused_static_libs deletes the archives these exported targets point at, so leaving the
+    packages in place would make a downstream find_package(Clang) fail its imported-file existence
+    check. Nothing FreeCAD builds consumes these packages. Returns the number of directories removed.
+    """
+    print("Removing orphaned LLVM, Clang, and LLD CMake packages")
+    cmake_dir = os.path.join(base_path, "lib", "cmake")
+    if not os.path.isdir(cmake_dir):
+        return 0
+
+    removed = 0
+    for name in _ORPHANED_LLVM_CMAKE_DIRS:
+        target = os.path.join(cmake_dir, name)
+        if not os.path.isdir(target):
+            continue
+        try:
+            shutil.rmtree(target)
+            removed += 1
+        except OSError as e:
+            print(f"Failed to delete {target}: {e}")
+    return removed
+
+
 _DOCUMENTATION_RELATIVE_DIRS = (
     os.path.join("doc"),
     os.path.join("share", "doc"),

--- a/test_path_cleaner.py
+++ b/test_path_cleaner.py
@@ -230,6 +230,51 @@ class TestDeleteUnusedStaticLibs(unittest.TestCase):
         self.assertEqual(path_cleaner.delete_unused_static_libs(self.base_dir), 0)
 
 
+class TestDeleteLlvmCmakePackages(unittest.TestCase):
+    """Verifies that the orphaned LLVM, Clang, and LLD CMake packages are removed and nothing else is."""
+
+    def setUp(self):
+        self.base_dir = tempfile.mkdtemp(prefix="libpack_test_")
+        self.cmake_dir = os.path.join(self.base_dir, "lib", "cmake")
+        os.makedirs(self.cmake_dir)
+
+    def tearDown(self):
+        shutil.rmtree(self.base_dir, ignore_errors=True)
+
+    def _make_package(self, name: str) -> str:
+        path = os.path.join(self.cmake_dir, name)
+        os.makedirs(path)
+        with open(os.path.join(path, f"{name}Config.cmake"), "w", encoding="utf-8") as f:
+            f.write("x")
+        return path
+
+    def test_removes_llvm_clang_lld_packages(self):
+        """The llvm, clang, and lld CMake package directories should be removed."""
+        targets = [self._make_package(n) for n in ("llvm", "clang", "lld")]
+
+        removed = path_cleaner.delete_llvm_cmake_packages(self.base_dir)
+
+        self.assertEqual(removed, len(targets))
+        for path in targets:
+            self.assertFalse(os.path.exists(path), f"Expected {path} to be removed")
+
+    def test_preserves_other_packages(self):
+        """Unrelated CMake packages must not be touched."""
+        keepers = [self._make_package(n) for n in ("Qt6Core", "Shiboken6", "zstd")]
+
+        removed = path_cleaner.delete_llvm_cmake_packages(self.base_dir)
+
+        self.assertEqual(removed, 0)
+        for path in keepers:
+            self.assertTrue(os.path.exists(path), f"Expected {path} to be preserved")
+
+    def test_no_cmake_dir_is_not_an_error(self):
+        """If the LibPack has no lib/cmake/ directory the function should be a no-op."""
+        shutil.rmtree(self.cmake_dir)
+
+        self.assertEqual(path_cleaner.delete_llvm_cmake_packages(self.base_dir), 0)
+
+
 class TestDeleteDocumentation(unittest.TestCase):
     """Verifies that share/doc and the top-level Qt qdoc input directory are both removed."""
 


### PR DESCRIPTION
The latest version of libclang as provided by Qt comes with a bundled CPython. This is both enormous and conflicts with the CPython being built by the LibPack. Remove it during the cleanup process.